### PR TITLE
Allow HTTPlug 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.2
+        - php: 7.3
 
 install:
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## To be released
+
+* Support HTTPlug 2
+
 ## 1.1 (2019-02-21)
 
 * Add support for Slack Blocks in chat.postMessage and better patch support for specification

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "jane-php/json-schema-runtime": "^4.0",
         "jane-php/open-api-runtime": "^4.0",
         "php-http/client-implementation": "*",
-        "php-http/client-common": "^1.7"
+        "php-http/client-common": "^1.7 || 2.0"
     },
     "require-dev": {
         "jane-php/jane-php": "^4.0",


### PR DESCRIPTION
This should allow Slack PHP Api client to be installed with HTTPlug 2.

Fix #8 