### PR TITLE
Fix #18, add "blocks" to all the messages API (updates, ephemeral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **Specification override** Fix "priority" type from integer to float
 * **Specification override** Add "id", "callback_id" and "actions" mapping to attachments (in Messages)
 * **Specification override** Map the "files" key in Message objects
+* **Specification override** Add "blocks" to all the messages API (updates, ephemeral)
 
 ## 1.1.3 (2019-03-21)
 

--- a/generated/Client.php
+++ b/generated/Client.php
@@ -560,6 +560,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $attachments a JSON-based array of structured attachments, presented as a URL-encoded string
+     *     @var string $blocks a JSON-based array of structured blocks, presented as a URL-encoded string
      *     @var string $text Text of the message to send. See below for an explanation of [formatting](#formatting). This field is usually required, unless you're providing only `attachments` instead.
      *     @var bool $link_names find and link channel names and usernames
      *     @var string $parse Change how messages are treated. Defaults to `none`. See [below](#formatting).
@@ -651,6 +652,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $attachments A JSON-based array of structured attachments, presented as a URL-encoded string. This field is required when not presenting `text`.
+     *     @var string $blocks a JSON-based array of structured blocks, presented as a URL-encoded string
      *     @var string $text New text for the message, using the [default formatting rules](/docs/formatting). It's not required when presenting `attachments`.
      *     @var string $ts timestamp of the message to be updated
      *     @var string $parse Change how messages are treated. Defaults to `client`, unlike `chat.postMessage`. See [below](#formatting).

--- a/generated/Endpoint/ChatPostEphemeral.php
+++ b/generated/Endpoint/ChatPostEphemeral.php
@@ -18,6 +18,7 @@ class ChatPostEphemeral extends \Jane\OpenApiRuntime\Client\BaseEndpoint impleme
      * @param array $formParameters {
      *
      *     @var string $attachments a JSON-based array of structured attachments, presented as a URL-encoded string
+     *     @var string $blocks a JSON-based array of structured blocks, presented as a URL-encoded string
      *     @var string $text Text of the message to send. See below for an explanation of [formatting](#formatting). This field is usually required, unless you're providing only `attachments` instead.
      *     @var bool $link_names find and link channel names and usernames
      *     @var string $parse Change how messages are treated. Defaults to `none`. See [below](#formatting).
@@ -62,10 +63,11 @@ class ChatPostEphemeral extends \Jane\OpenApiRuntime\Client\BaseEndpoint impleme
     protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getFormOptionsResolver();
-        $optionsResolver->setDefined(['attachments', 'text', 'link_names', 'parse', 'user', 'as_user', 'channel']);
+        $optionsResolver->setDefined(['attachments', 'blocks', 'text', 'link_names', 'parse', 'user', 'as_user', 'channel']);
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('attachments', ['string']);
+        $optionsResolver->setAllowedTypes('blocks', ['string']);
         $optionsResolver->setAllowedTypes('text', ['string']);
         $optionsResolver->setAllowedTypes('link_names', ['bool']);
         $optionsResolver->setAllowedTypes('parse', ['string']);

--- a/generated/Endpoint/ChatUpdate.php
+++ b/generated/Endpoint/ChatUpdate.php
@@ -18,6 +18,7 @@ class ChatUpdate extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
      * @param array $formParameters {
      *
      *     @var string $attachments A JSON-based array of structured attachments, presented as a URL-encoded string. This field is required when not presenting `text`.
+     *     @var string $blocks a JSON-based array of structured blocks, presented as a URL-encoded string
      *     @var string $text New text for the message, using the [default formatting rules](/docs/formatting). It's not required when presenting `attachments`.
      *     @var string $ts timestamp of the message to be updated
      *     @var string $parse Change how messages are treated. Defaults to `client`, unlike `chat.postMessage`. See [below](#formatting).
@@ -62,10 +63,11 @@ class ChatUpdate extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
     protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getFormOptionsResolver();
-        $optionsResolver->setDefined(['attachments', 'text', 'ts', 'parse', 'as_user', 'link_names', 'channel']);
+        $optionsResolver->setDefined(['attachments', 'blocks', 'text', 'ts', 'parse', 'as_user', 'link_names', 'channel']);
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('attachments', ['string']);
+        $optionsResolver->setAllowedTypes('blocks', ['string']);
         $optionsResolver->setAllowedTypes('text', ['string']);
         $optionsResolver->setAllowedTypes('ts', ['string']);
         $optionsResolver->setAllowedTypes('parse', ['string']);

--- a/resources/patches/10-blocks-in-all-api.patch
+++ b/resources/patches/10-blocks-in-all-api.patch
@@ -1,0 +1,28 @@
+--- resources/slack-openapi-patched.json
++++ resources/slack-openapi-patched.json
+@@ -6641,6 +6641,12 @@
+                         "name": "attachments",
+                         "type": "string"
+                     },
++                    {
++                        "description": "A JSON-based array of structured blocks, presented as a URL-encoded string.",
++                        "in": "formData",
++                        "name": "blocks",
++                        "type": "string"
++                    },
+                     {
+                         "description": "Text of the message to send. See below for an explanation of [formatting](#formatting). This field is usually required, unless you're providing only `attachments` instead.",
+                         "in": "formData",
+@@ -7173,6 +7179,12 @@
+                         "name": "attachments",
+                         "type": "string"
+                     },
++                    {
++                        "description": "A JSON-based array of structured blocks, presented as a URL-encoded string.",
++                        "in": "formData",
++                        "name": "blocks",
++                        "type": "string"
++                    },
+                     {
+                         "description": "New text for the message, using the [default formatting rules](/docs/formatting). It's not required when presenting `attachments`.",
+                         "in": "formData",

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -6642,6 +6642,12 @@
                         "type": "string"
                     },
                     {
+                        "description": "A JSON-based array of structured blocks, presented as a URL-encoded string.",
+                        "in": "formData",
+                        "name": "blocks",
+                        "type": "string"
+                    },
+                    {
                         "description": "Text of the message to send. See below for an explanation of [formatting](#formatting). This field is usually required, unless you're providing only `attachments` instead.",
                         "in": "formData",
                         "name": "text",
@@ -7171,6 +7177,12 @@
                         "description": "A JSON-based array of structured attachments, presented as a URL-encoded string. This field is required when not presenting `text`.",
                         "in": "formData",
                         "name": "attachments",
+                        "type": "string"
+                    },
+                    {
+                        "description": "A JSON-based array of structured blocks, presented as a URL-encoded string.",
+                        "in": "formData",
+                        "name": "blocks",
                         "type": "string"
                     },
                     {


### PR DESCRIPTION
Fix #18 

The "blocks" field was missing from some endpoints.