### PR TITLE
Change thread_ts for endpoint chat.postMessage from float to string.

### DIFF
--- a/generated/Client.php
+++ b/generated/Client.php
@@ -589,7 +589,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $username Set your bot's user name. Must be used in conjunction with `as_user` set to false, otherwise ignored. See [authorship](#authorship) below.
-     *     @var float $thread_ts Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.
+     *     @var string $thread_ts Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.
      *     @var string $attachments a JSON-based array of structured attachments, presented as a URL-encoded string
      *     @var string $blocks a JSON-based array of structured blocks, presented as a URL-encoded string
      *     @var bool $unfurl_links pass true to enable unfurling of primarily text-based content

--- a/generated/Client.php
+++ b/generated/Client.php
@@ -406,7 +406,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts Unique identifier of a thread's parent message
+     *     @var string $thread_ts Unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `channels:history`
      *     @var string $channel Channel to fetch thread from
      * }
@@ -1662,7 +1662,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts Unique identifier of a thread's parent message
+     *     @var string $thread_ts Unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `groups:history`
      *     @var string $channel Private channel to fetch thread from
      * }
@@ -1860,7 +1860,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts Unique identifier of a thread's parent message
+     *     @var string $thread_ts Unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `im:history`
      *     @var string $channel Direct message channel to fetch thread from
      * }
@@ -2005,7 +2005,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts unique identifier of a thread's parent message
+     *     @var string $thread_ts unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `mpim:history`
      *     @var string $channel Multiparty direct message channel to fetch thread from.
      * }

--- a/generated/Endpoint/ChannelsReplies.php
+++ b/generated/Endpoint/ChannelsReplies.php
@@ -17,7 +17,7 @@ class ChannelsReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts Unique identifier of a thread's parent message
+     *     @var string $thread_ts Unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `channels:history`
      *     @var string $channel Channel to fetch thread from
      * }
@@ -55,7 +55,7 @@ class ChannelsReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(['thread_ts', 'token', 'channel']);
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
-        $optionsResolver->setAllowedTypes('thread_ts', ['float']);
+        $optionsResolver->setAllowedTypes('thread_ts', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/ChatPostMessage.php
+++ b/generated/Endpoint/ChatPostMessage.php
@@ -18,7 +18,7 @@ class ChatPostMessage extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
      * @param array $formParameters {
      *
      *     @var string $username Set your bot's user name. Must be used in conjunction with `as_user` set to false, otherwise ignored. See [authorship](#authorship) below.
-     *     @var float $thread_ts Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.
+     *     @var string $thread_ts Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.
      *     @var string $attachments a JSON-based array of structured attachments, presented as a URL-encoded string
      *     @var string $blocks a JSON-based array of structured blocks, presented as a URL-encoded string
      *     @var bool $unfurl_links pass true to enable unfurling of primarily text-based content
@@ -74,7 +74,7 @@ class ChatPostMessage extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('username', ['string']);
-        $optionsResolver->setAllowedTypes('thread_ts', ['float']);
+        $optionsResolver->setAllowedTypes('thread_ts', ['string']);
         $optionsResolver->setAllowedTypes('attachments', ['string']);
         $optionsResolver->setAllowedTypes('blocks', ['string']);
         $optionsResolver->setAllowedTypes('unfurl_links', ['bool']);

--- a/generated/Endpoint/GroupsReplies.php
+++ b/generated/Endpoint/GroupsReplies.php
@@ -17,7 +17,7 @@ class GroupsReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements 
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts Unique identifier of a thread's parent message
+     *     @var string $thread_ts Unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `groups:history`
      *     @var string $channel Private channel to fetch thread from
      * }
@@ -55,7 +55,7 @@ class GroupsReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(['thread_ts', 'token', 'channel']);
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
-        $optionsResolver->setAllowedTypes('thread_ts', ['float']);
+        $optionsResolver->setAllowedTypes('thread_ts', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/ImReplies.php
+++ b/generated/Endpoint/ImReplies.php
@@ -17,7 +17,7 @@ class ImReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jan
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts Unique identifier of a thread's parent message
+     *     @var string $thread_ts Unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `im:history`
      *     @var string $channel Direct message channel to fetch thread from
      * }
@@ -55,7 +55,7 @@ class ImReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jan
         $optionsResolver->setDefined(['thread_ts', 'token', 'channel']);
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
-        $optionsResolver->setAllowedTypes('thread_ts', ['float']);
+        $optionsResolver->setAllowedTypes('thread_ts', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/MpimReplies.php
+++ b/generated/Endpoint/MpimReplies.php
@@ -17,7 +17,7 @@ class MpimReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      *
      * @param array $queryParameters {
      *
-     *     @var float $thread_ts unique identifier of a thread's parent message
+     *     @var string $thread_ts unique identifier of a thread's parent message
      *     @var string $token Authentication token. Requires scope: `mpim:history`
      *     @var string $channel Multiparty direct message channel to fetch thread from.
      * }
@@ -55,7 +55,7 @@ class MpimReplies extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
         $optionsResolver->setDefined(['thread_ts', 'token', 'channel']);
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
-        $optionsResolver->setAllowedTypes('thread_ts', ['float']);
+        $optionsResolver->setAllowedTypes('thread_ts', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Model/ChatDeletePostResponse200.php
+++ b/generated/Model/ChatDeletePostResponse200.php
@@ -21,7 +21,7 @@ class ChatDeletePostResponse200 extends \ArrayObject
      */
     protected $ok;
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
 
@@ -66,7 +66,7 @@ class ChatDeletePostResponse200 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -74,7 +74,7 @@ class ChatDeletePostResponse200 extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ChatPostEphemeralPostResponse200.php
+++ b/generated/Model/ChatPostEphemeralPostResponse200.php
@@ -13,7 +13,7 @@ namespace JoliCode\Slack\Api\Model;
 class ChatPostEphemeralPostResponse200 extends \ArrayObject
 {
     /**
-     * @var float|string
+     * @var string
      */
     protected $messageTs;
     /**
@@ -22,7 +22,7 @@ class ChatPostEphemeralPostResponse200 extends \ArrayObject
     protected $ok;
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getMessageTs()
     {
@@ -30,7 +30,7 @@ class ChatPostEphemeralPostResponse200 extends \ArrayObject
     }
 
     /**
-     * @param float|string $messageTs
+     * @param string $messageTs
      *
      * @return self
      */

--- a/generated/Model/ChatPostMessagePostResponse200.php
+++ b/generated/Model/ChatPostMessagePostResponse200.php
@@ -25,7 +25,7 @@ class ChatPostMessagePostResponse200 extends \ArrayObject
      */
     protected $ok;
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
 
@@ -90,7 +90,7 @@ class ChatPostMessagePostResponse200 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -98,7 +98,7 @@ class ChatPostMessagePostResponse200 extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ChatUpdatePostResponse200.php
+++ b/generated/Model/ChatUpdatePostResponse200.php
@@ -25,7 +25,7 @@ class ChatUpdatePostResponse200 extends \ArrayObject
      */
     protected $text;
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
 
@@ -90,7 +90,7 @@ class ChatUpdatePostResponse200 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -98,7 +98,7 @@ class ChatUpdatePostResponse200 extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ConversationsRepliesGetResponse200MessagesItemItem0.php
+++ b/generated/Model/ConversationsRepliesGetResponse200MessagesItemItem0.php
@@ -13,7 +13,7 @@ namespace JoliCode\Slack\Api\Model;
 class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
 {
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -41,11 +41,11 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
      */
     protected $text;
     /**
-     * @var float|string
+     * @var string
      */
     protected $threadTs;
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
     /**
@@ -70,7 +70,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
     protected $userTeam;
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -78,7 +78,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */
@@ -210,7 +210,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getThreadTs()
     {
@@ -218,7 +218,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
     }
 
     /**
-     * @param float|string $threadTs
+     * @param string $threadTs
      *
      * @return self
      */
@@ -230,7 +230,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -238,7 +238,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0 extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ConversationsRepliesGetResponse200MessagesItemItem0RepliesItem.php
+++ b/generated/Model/ConversationsRepliesGetResponse200MessagesItemItem0RepliesItem.php
@@ -13,7 +13,7 @@ namespace JoliCode\Slack\Api\Model;
 class ConversationsRepliesGetResponse200MessagesItemItem0RepliesItem extends \ArrayObject
 {
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
     /**
@@ -22,7 +22,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0RepliesItem extends \Ar
     protected $user;
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -30,7 +30,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0RepliesItem extends \Ar
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ConversationsRepliesGetResponse200MessagesItemItem1.php
+++ b/generated/Model/ConversationsRepliesGetResponse200MessagesItemItem1.php
@@ -33,11 +33,11 @@ class ConversationsRepliesGetResponse200MessagesItemItem1 extends \ArrayObject
      */
     protected $text;
     /**
-     * @var float|string
+     * @var string
      */
     protected $threadTs;
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
     /**
@@ -158,7 +158,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem1 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getThreadTs()
     {
@@ -166,7 +166,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem1 extends \ArrayObject
     }
 
     /**
-     * @param float|string $threadTs
+     * @param string $threadTs
      *
      * @return self
      */
@@ -178,7 +178,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem1 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -186,7 +186,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem1 extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ImOpenPostResponse200Channel.php
+++ b/generated/Model/ImOpenPostResponse200Channel.php
@@ -29,7 +29,7 @@ class ImOpenPostResponse200Channel extends \ArrayObject
      */
     protected $isOpen;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -130,7 +130,7 @@ class ImOpenPostResponse200Channel extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -138,7 +138,7 @@ class ImOpenPostResponse200Channel extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */

--- a/generated/Model/ObjsChannel.php
+++ b/generated/Model/ObjsChannel.php
@@ -73,7 +73,7 @@ class ObjsChannel extends \ArrayObject
      */
     protected $isShared;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -430,7 +430,7 @@ class ObjsChannel extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -438,7 +438,7 @@ class ObjsChannel extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */

--- a/generated/Model/ObjsConversationItem0.php
+++ b/generated/Model/ObjsConversationItem0.php
@@ -97,7 +97,7 @@ class ObjsConversationItem0 extends \ArrayObject
      */
     protected $isShared;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -594,7 +594,7 @@ class ObjsConversationItem0 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -602,7 +602,7 @@ class ObjsConversationItem0 extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */

--- a/generated/Model/ObjsConversationItem1.php
+++ b/generated/Model/ObjsConversationItem1.php
@@ -93,7 +93,7 @@ class ObjsConversationItem1 extends \ArrayObject
      */
     protected $isShared;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -570,7 +570,7 @@ class ObjsConversationItem1 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -578,7 +578,7 @@ class ObjsConversationItem1 extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */

--- a/generated/Model/ObjsConversationItem2.php
+++ b/generated/Model/ObjsConversationItem2.php
@@ -49,7 +49,7 @@ class ObjsConversationItem2 extends \ArrayObject
      */
     protected $isUserDeleted;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -254,7 +254,7 @@ class ObjsConversationItem2 extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -262,7 +262,7 @@ class ObjsConversationItem2 extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */

--- a/generated/Model/ObjsGroup.php
+++ b/generated/Model/ObjsGroup.php
@@ -49,7 +49,7 @@ class ObjsGroup extends \ArrayObject
      */
     protected $isPendingExtShared;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -270,7 +270,7 @@ class ObjsGroup extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -278,7 +278,7 @@ class ObjsGroup extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */

--- a/generated/Model/ObjsMessage.php
+++ b/generated/Model/ObjsMessage.php
@@ -49,7 +49,7 @@ class ObjsMessage extends \ArrayObject
      */
     protected $isIntro;
     /**
-     * @var float|string
+     * @var string
      */
     protected $lastRead;
     /**
@@ -105,7 +105,7 @@ class ObjsMessage extends \ArrayObject
      */
     protected $text;
     /**
-     * @var float|string
+     * @var string
      */
     protected $threadTs;
     /**
@@ -113,7 +113,7 @@ class ObjsMessage extends \ArrayObject
      */
     protected $topic;
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
     /**
@@ -326,7 +326,7 @@ class ObjsMessage extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getLastRead()
     {
@@ -334,7 +334,7 @@ class ObjsMessage extends \ArrayObject
     }
 
     /**
-     * @param float|string $lastRead
+     * @param string $lastRead
      *
      * @return self
      */
@@ -606,7 +606,7 @@ class ObjsMessage extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getThreadTs()
     {
@@ -614,7 +614,7 @@ class ObjsMessage extends \ArrayObject
     }
 
     /**
-     * @param float|string $threadTs
+     * @param string $threadTs
      *
      * @return self
      */
@@ -646,7 +646,7 @@ class ObjsMessage extends \ArrayObject
     }
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -654,7 +654,7 @@ class ObjsMessage extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Model/ObjsMessageRepliesItem.php
+++ b/generated/Model/ObjsMessageRepliesItem.php
@@ -13,7 +13,7 @@ namespace JoliCode\Slack\Api\Model;
 class ObjsMessageRepliesItem extends \ArrayObject
 {
     /**
-     * @var float|string
+     * @var string
      */
     protected $ts;
     /**
@@ -22,7 +22,7 @@ class ObjsMessageRepliesItem extends \ArrayObject
     protected $user;
 
     /**
-     * @return float|string
+     * @return string
      */
     public function getTs()
     {
@@ -30,7 +30,7 @@ class ObjsMessageRepliesItem extends \ArrayObject
     }
 
     /**
-     * @param float|string $ts
+     * @param string $ts
      *
      * @return self
      */

--- a/generated/Normalizer/ChatDeletePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatDeletePostResponse200Normalizer.php
@@ -54,9 +54,7 @@ class ChatDeletePostResponse200Normalizer implements DenormalizerInterface, Norm
         }
         if (property_exists($data, 'ts')) {
             $value = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value = $data->{'ts'};
             }
             $object->setTs($value);
@@ -82,9 +80,7 @@ class ChatDeletePostResponse200Normalizer implements DenormalizerInterface, Norm
         }
         if (null !== $object->getTs()) {
             $value = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value = $object->getTs();
             }
             $data->{'ts'} = $value;

--- a/generated/Normalizer/ChatPostEphemeralPostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatPostEphemeralPostResponse200Normalizer.php
@@ -46,9 +46,7 @@ class ChatPostEphemeralPostResponse200Normalizer implements DenormalizerInterfac
         $data = clone $data;
         if (property_exists($data, 'message_ts')) {
             $value = $data->{'message_ts'};
-            if (is_float($data->{'message_ts'})) {
-                $value = $data->{'message_ts'};
-            } elseif (is_string($data->{'message_ts'})) {
+            if (is_string($data->{'message_ts'})) {
                 $value = $data->{'message_ts'};
             }
             $object->setMessageTs($value);
@@ -72,9 +70,7 @@ class ChatPostEphemeralPostResponse200Normalizer implements DenormalizerInterfac
         $data = new \stdClass();
         if (null !== $object->getMessageTs()) {
             $value = $object->getMessageTs();
-            if (is_float($object->getMessageTs())) {
-                $value = $object->getMessageTs();
-            } elseif (is_string($object->getMessageTs())) {
+            if (is_string($object->getMessageTs())) {
                 $value = $object->getMessageTs();
             }
             $data->{'message_ts'} = $value;

--- a/generated/Normalizer/ChatPostMessagePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatPostMessagePostResponse200Normalizer.php
@@ -58,9 +58,7 @@ class ChatPostMessagePostResponse200Normalizer implements DenormalizerInterface,
         }
         if (property_exists($data, 'ts')) {
             $value = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value = $data->{'ts'};
             }
             $object->setTs($value);
@@ -89,9 +87,7 @@ class ChatPostMessagePostResponse200Normalizer implements DenormalizerInterface,
         }
         if (null !== $object->getTs()) {
             $value = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value = $object->getTs();
             }
             $data->{'ts'} = $value;

--- a/generated/Normalizer/ChatUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatUpdatePostResponse200Normalizer.php
@@ -58,9 +58,7 @@ class ChatUpdatePostResponse200Normalizer implements DenormalizerInterface, Norm
         }
         if (property_exists($data, 'ts')) {
             $value = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value = $data->{'ts'};
             }
             $object->setTs($value);
@@ -89,9 +87,7 @@ class ChatUpdatePostResponse200Normalizer implements DenormalizerInterface, Norm
         }
         if (null !== $object->getTs()) {
             $value = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value = $object->getTs();
             }
             $data->{'ts'} = $value;

--- a/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem0Normalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem0Normalizer.php
@@ -46,9 +46,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0Normalizer implements D
         $data = clone $data;
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -84,9 +82,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0Normalizer implements D
         }
         if (property_exists($data, 'thread_ts')) {
             $value_2 = $data->{'thread_ts'};
-            if (is_float($data->{'thread_ts'})) {
-                $value_2 = $data->{'thread_ts'};
-            } elseif (is_string($data->{'thread_ts'})) {
+            if (is_string($data->{'thread_ts'})) {
                 $value_2 = $data->{'thread_ts'};
             }
             $object->setThreadTs($value_2);
@@ -94,9 +90,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0Normalizer implements D
         }
         if (property_exists($data, 'ts')) {
             $value_3 = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value_3 = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value_3 = $data->{'ts'};
             }
             $object->setTs($value_3);
@@ -136,9 +130,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0Normalizer implements D
         $data = new \stdClass();
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;
@@ -167,18 +159,14 @@ class ConversationsRepliesGetResponse200MessagesItemItem0Normalizer implements D
         }
         if (null !== $object->getThreadTs()) {
             $value_2 = $object->getThreadTs();
-            if (is_float($object->getThreadTs())) {
-                $value_2 = $object->getThreadTs();
-            } elseif (is_string($object->getThreadTs())) {
+            if (is_string($object->getThreadTs())) {
                 $value_2 = $object->getThreadTs();
             }
             $data->{'thread_ts'} = $value_2;
         }
         if (null !== $object->getTs()) {
             $value_3 = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value_3 = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value_3 = $object->getTs();
             }
             $data->{'ts'} = $value_3;

--- a/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem0RepliesItemNormalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem0RepliesItemNormalizer.php
@@ -46,9 +46,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0RepliesItemNormalizer i
         $data = clone $data;
         if (property_exists($data, 'ts')) {
             $value = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value = $data->{'ts'};
             }
             $object->setTs($value);
@@ -72,9 +70,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem0RepliesItemNormalizer i
         $data = new \stdClass();
         if (null !== $object->getTs()) {
             $value = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value = $object->getTs();
             }
             $data->{'ts'} = $value;

--- a/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem1Normalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem1Normalizer.php
@@ -66,9 +66,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem1Normalizer implements D
         }
         if (property_exists($data, 'thread_ts')) {
             $value = $data->{'thread_ts'};
-            if (is_float($data->{'thread_ts'})) {
-                $value = $data->{'thread_ts'};
-            } elseif (is_string($data->{'thread_ts'})) {
+            if (is_string($data->{'thread_ts'})) {
                 $value = $data->{'thread_ts'};
             }
             $object->setThreadTs($value);
@@ -76,9 +74,7 @@ class ConversationsRepliesGetResponse200MessagesItemItem1Normalizer implements D
         }
         if (property_exists($data, 'ts')) {
             $value_1 = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value_1 = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value_1 = $data->{'ts'};
             }
             $object->setTs($value_1);
@@ -129,18 +125,14 @@ class ConversationsRepliesGetResponse200MessagesItemItem1Normalizer implements D
         }
         if (null !== $object->getThreadTs()) {
             $value = $object->getThreadTs();
-            if (is_float($object->getThreadTs())) {
-                $value = $object->getThreadTs();
-            } elseif (is_string($object->getThreadTs())) {
+            if (is_string($object->getThreadTs())) {
                 $value = $object->getThreadTs();
             }
             $data->{'thread_ts'} = $value;
         }
         if (null !== $object->getTs()) {
             $value_1 = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value_1 = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value_1 = $object->getTs();
             }
             $data->{'ts'} = $value_1;

--- a/generated/Normalizer/ImOpenPostResponse200ChannelNormalizer.php
+++ b/generated/Normalizer/ImOpenPostResponse200ChannelNormalizer.php
@@ -62,9 +62,7 @@ class ImOpenPostResponse200ChannelNormalizer implements DenormalizerInterface, N
         }
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -112,9 +110,7 @@ class ImOpenPostResponse200ChannelNormalizer implements DenormalizerInterface, N
         }
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;

--- a/generated/Normalizer/ObjsChannelNormalizer.php
+++ b/generated/Normalizer/ObjsChannelNormalizer.php
@@ -106,9 +106,7 @@ class ObjsChannelNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -237,9 +235,7 @@ class ObjsChannelNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;

--- a/generated/Normalizer/ObjsConversationItem0Normalizer.php
+++ b/generated/Normalizer/ObjsConversationItem0Normalizer.php
@@ -130,9 +130,7 @@ class ObjsConversationItem0Normalizer implements DenormalizerInterface, Normaliz
         }
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -307,9 +305,7 @@ class ObjsConversationItem0Normalizer implements DenormalizerInterface, Normaliz
         }
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;

--- a/generated/Normalizer/ObjsConversationItem1Normalizer.php
+++ b/generated/Normalizer/ObjsConversationItem1Normalizer.php
@@ -126,9 +126,7 @@ class ObjsConversationItem1Normalizer implements DenormalizerInterface, Normaliz
         }
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -300,9 +298,7 @@ class ObjsConversationItem1Normalizer implements DenormalizerInterface, Normaliz
         }
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;

--- a/generated/Normalizer/ObjsConversationItem2Normalizer.php
+++ b/generated/Normalizer/ObjsConversationItem2Normalizer.php
@@ -82,9 +82,7 @@ class ObjsConversationItem2Normalizer implements DenormalizerInterface, Normaliz
         }
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -151,9 +149,7 @@ class ObjsConversationItem2Normalizer implements DenormalizerInterface, Normaliz
         }
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;

--- a/generated/Normalizer/ObjsGroupNormalizer.php
+++ b/generated/Normalizer/ObjsGroupNormalizer.php
@@ -82,9 +82,7 @@ class ObjsGroupNormalizer implements DenormalizerInterface, NormalizerInterface,
         }
         if (property_exists($data, 'last_read')) {
             $value = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value = $data->{'last_read'};
             }
             $object->setLastRead($value);
@@ -171,9 +169,7 @@ class ObjsGroupNormalizer implements DenormalizerInterface, NormalizerInterface,
         }
         if (null !== $object->getLastRead()) {
             $value = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value = $object->getLastRead();
             }
             $data->{'last_read'} = $value;

--- a/generated/Normalizer/ObjsMessageNormalizer.php
+++ b/generated/Normalizer/ObjsMessageNormalizer.php
@@ -90,9 +90,7 @@ class ObjsMessageNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (property_exists($data, 'last_read')) {
             $value_2 = $data->{'last_read'};
-            if (is_float($data->{'last_read'})) {
-                $value_2 = $data->{'last_read'};
-            } elseif (is_string($data->{'last_read'})) {
+            if (is_string($data->{'last_read'})) {
                 $value_2 = $data->{'last_read'};
             }
             $object->setLastRead($value_2);
@@ -164,9 +162,7 @@ class ObjsMessageNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (property_exists($data, 'thread_ts')) {
             $value_6 = $data->{'thread_ts'};
-            if (is_float($data->{'thread_ts'})) {
-                $value_6 = $data->{'thread_ts'};
-            } elseif (is_string($data->{'thread_ts'})) {
+            if (is_string($data->{'thread_ts'})) {
                 $value_6 = $data->{'thread_ts'};
             }
             $object->setThreadTs($value_6);
@@ -178,9 +174,7 @@ class ObjsMessageNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (property_exists($data, 'ts')) {
             $value_7 = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value_7 = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value_7 = $data->{'ts'};
             }
             $object->setTs($value_7);
@@ -263,9 +257,7 @@ class ObjsMessageNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (null !== $object->getLastRead()) {
             $value_2 = $object->getLastRead();
-            if (is_float($object->getLastRead())) {
-                $value_2 = $object->getLastRead();
-            } elseif (is_string($object->getLastRead())) {
+            if (is_string($object->getLastRead())) {
                 $value_2 = $object->getLastRead();
             }
             $data->{'last_read'} = $value_2;
@@ -323,9 +315,7 @@ class ObjsMessageNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (null !== $object->getThreadTs()) {
             $value_6 = $object->getThreadTs();
-            if (is_float($object->getThreadTs())) {
-                $value_6 = $object->getThreadTs();
-            } elseif (is_string($object->getThreadTs())) {
+            if (is_string($object->getThreadTs())) {
                 $value_6 = $object->getThreadTs();
             }
             $data->{'thread_ts'} = $value_6;
@@ -335,9 +325,7 @@ class ObjsMessageNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (null !== $object->getTs()) {
             $value_7 = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value_7 = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value_7 = $object->getTs();
             }
             $data->{'ts'} = $value_7;

--- a/generated/Normalizer/ObjsMessageRepliesItemNormalizer.php
+++ b/generated/Normalizer/ObjsMessageRepliesItemNormalizer.php
@@ -46,9 +46,7 @@ class ObjsMessageRepliesItemNormalizer implements DenormalizerInterface, Normali
         $data = clone $data;
         if (property_exists($data, 'ts')) {
             $value = $data->{'ts'};
-            if (is_float($data->{'ts'})) {
-                $value = $data->{'ts'};
-            } elseif (is_string($data->{'ts'})) {
+            if (is_string($data->{'ts'})) {
                 $value = $data->{'ts'};
             }
             $object->setTs($value);
@@ -72,9 +70,7 @@ class ObjsMessageRepliesItemNormalizer implements DenormalizerInterface, Normali
         $data = new \stdClass();
         if (null !== $object->getTs()) {
             $value = $object->getTs();
-            if (is_float($object->getTs())) {
-                $value = $object->getTs();
-            } elseif (is_string($object->getTs())) {
+            if (is_string($object->getTs())) {
                 $value = $object->getTs();
             }
             $data->{'ts'} = $value;

--- a/resources/patches/11-chat.postmessage-timestamp-type.patch
+++ b/resources/patches/11-chat.postmessage-timestamp-type.patch
@@ -5,7 +5,7 @@ index 24d5ee0..4b2c628 100644
 @@ -101,7 +101,7 @@
          "defs_ts": {
              "pattern": "^\\d{10}\\.\\d{6}$",
-             "title": "Timestamp in format 0123456789.012345",
+             "title": "Timestamp in format 0123456789.012345 as string",
 -            "type": ["number", "string"]
 +            "type": ["string"]
          },

--- a/resources/patches/11-chat.postmessage-timestamp-type.patch
+++ b/resources/patches/11-chat.postmessage-timestamp-type.patch
@@ -1,0 +1,13 @@
+diff --git a/resources/slack-openapi-patched.json b/resources/slack-openapi-patched.json
+index a0cfe5a..24d5ee0 100644
+--- a/resources/slack-openapi-patched.json
++++ b/resources/slack-openapi-patched.json
+@@ -6812,7 +6812,7 @@
+                         "description": "Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.",
+                         "in": "formData",
+                         "name": "thread_ts",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "A JSON-based array of structured attachments, presented as a URL-encoded string.",

--- a/resources/patches/11-chat.postmessage-timestamp-type.patch
+++ b/resources/patches/11-chat.postmessage-timestamp-type.patch
@@ -1,13 +1,49 @@
 diff --git a/resources/slack-openapi-patched.json b/resources/slack-openapi-patched.json
-index a0cfe5a..24d5ee0 100644
+index 24d5ee0..4b2c628 100644
 --- a/resources/slack-openapi-patched.json
 +++ b/resources/slack-openapi-patched.json
-@@ -6812,7 +6812,7 @@
-                         "description": "Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.",
-                         "in": "formData",
+@@ -101,7 +101,7 @@
+         "defs_ts": {
+             "pattern": "^\\d{10}\\.\\d{6}$",
+             "title": "Timestamp in format 0123456789.012345",
+-            "type": ["number", "string"]
++            "type": ["string"]
+         },
+         "defs_user_id": {
+             "pattern": "^[UW][A-Z0-9]{8}$",
+@@ -5830,7 +5830,7 @@
+                         "description": "Unique identifier of a thread's parent message",
+                         "in": "query",
                          "name": "thread_ts",
 -                        "type": "number"
 +                        "type": "string"
                      },
                      {
-                         "description": "A JSON-based array of structured attachments, presented as a URL-encoded string.",
+                         "description": "Authentication token. Requires scope: `channels:history`",
+@@ -13411,7 +13411,7 @@
+                         "description": "Unique identifier of a thread's parent message",
+                         "in": "query",
+                         "name": "thread_ts",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `groups:history`",
+@@ -14600,7 +14600,7 @@
+                         "description": "Unique identifier of a thread's parent message",
+                         "in": "query",
+                         "name": "thread_ts",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `im:history`",
+@@ -15410,7 +15410,7 @@
+                         "description": "Unique identifier of a thread's parent message.",
+                         "in": "query",
+                         "name": "thread_ts",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `mpim:history`",

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -6812,7 +6812,7 @@
                         "description": "Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.",
                         "in": "formData",
                         "name": "thread_ts",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "A JSON-based array of structured attachments, presented as a URL-encoded string.",

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -100,8 +100,8 @@
         },
         "defs_ts": {
             "pattern": "^\\d{10}\\.\\d{6}$",
-            "title": "Timestamp in format 0123456789.012345",
-            "type": ["number", "string"]
+            "title": "Timestamp in format 0123456789.012345 as string",
+            "type": ["string"]
         },
         "defs_user_id": {
             "pattern": "^[UW][A-Z0-9]{8}$",
@@ -5830,7 +5830,7 @@
                         "description": "Unique identifier of a thread's parent message",
                         "in": "query",
                         "name": "thread_ts",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `channels:history`",
@@ -13411,7 +13411,7 @@
                         "description": "Unique identifier of a thread's parent message",
                         "in": "query",
                         "name": "thread_ts",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `groups:history`",
@@ -14600,7 +14600,7 @@
                         "description": "Unique identifier of a thread's parent message",
                         "in": "query",
                         "name": "thread_ts",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `im:history`",
@@ -15410,7 +15410,7 @@
                         "description": "Unique identifier of a thread's parent message.",
                         "in": "query",
                         "name": "thread_ts",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `mpim:history`",


### PR DESCRIPTION
Related to #12, #13, #22 and #23:

Sending `thread_ts` as a float throw the client didn't create a thread for the slack conversation.

Example code:

```php
$client->chatPostMessage([
    'username' => $username,
    'channel' => $channel,
    'text' => $message,
    'thread_ts' => $timestamp,
]);
```