### PR TITLE
Endpoints accepting floats instead of strings

### DIFF
--- a/generated/Client.php
+++ b/generated/Client.php
@@ -2067,7 +2067,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to pin
-     *     @var float $timestamp timestamp of the message to pin
+     *     @var string $timestamp timestamp of the message to pin
      *     @var string $file file to pin
      *     @var string $channel Channel to pin the item in.
      * }
@@ -2110,7 +2110,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to un-pin
-     *     @var float $timestamp timestamp of the message to un-pin
+     *     @var string $timestamp timestamp of the message to un-pin
      *     @var string $file file to un-pin
      *     @var string $channel Channel where the item is pinned to.
      * }
@@ -2136,7 +2136,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      *     @var string $name reaction (emoji) name
      *     @var string $file_comment file comment to add reaction to
-     *     @var float $timestamp timestamp of the message to add reaction to
+     *     @var string $timestamp timestamp of the message to add reaction to
      *     @var string $file file to add reaction to
      *     @var string $channel Channel where the message to add reaction to was posted.
      * }
@@ -2162,7 +2162,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      *     @var bool $full if true always return the complete reaction list
      *     @var string $file_comment file comment to get reactions for
-     *     @var float $timestamp timestamp of the message to get reactions for
+     *     @var string $timestamp timestamp of the message to get reactions for
      *     @var string $token Authentication token. Requires scope: `reactions:read`
      *     @var string $file file to get reactions for
      *     @var string $channel Channel where the message to get reactions for was posted.
@@ -2205,7 +2205,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      *
      *     @var string $name reaction (emoji) name
      *     @var string $file_comment file comment to remove reaction from
-     *     @var float $timestamp timestamp of the message to remove reaction from
+     *     @var string $timestamp timestamp of the message to remove reaction from
      *     @var string $file file to remove reaction from
      *     @var string $channel Channel where the message to remove reaction from was posted.
      * }
@@ -2445,7 +2445,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to add star to
-     *     @var float $timestamp timestamp of the message to add star to
+     *     @var string $timestamp timestamp of the message to add star to
      *     @var string $channel channel to add star to, or channel where the message to add star to was posted (used with `timestamp`)
      *     @var string $file File to add star to.
      * }
@@ -2489,7 +2489,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to remove star from
-     *     @var float $timestamp timestamp of the message to remove star from
+     *     @var string $timestamp timestamp of the message to remove star from
      *     @var string $channel channel to remove star from, or channel where the message to remove star from was posted (used with `timestamp`)
      *     @var string $file File to remove star from.
      * }

--- a/generated/Endpoint/PinsAdd.php
+++ b/generated/Endpoint/PinsAdd.php
@@ -18,7 +18,7 @@ class PinsAdd extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to pin
-     *     @var float $timestamp timestamp of the message to pin
+     *     @var string $timestamp timestamp of the message to pin
      *     @var string $file file to pin
      *     @var string $channel Channel to pin the item in.
      * }
@@ -63,7 +63,7 @@ class PinsAdd extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/PinsRemove.php
+++ b/generated/Endpoint/PinsRemove.php
@@ -18,7 +18,7 @@ class PinsRemove extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to un-pin
-     *     @var float $timestamp timestamp of the message to un-pin
+     *     @var string $timestamp timestamp of the message to un-pin
      *     @var string $file file to un-pin
      *     @var string $channel Channel where the item is pinned to.
      * }
@@ -63,7 +63,7 @@ class PinsRemove extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/ReactionsAdd.php
+++ b/generated/Endpoint/ReactionsAdd.php
@@ -19,7 +19,7 @@ class ReactionsAdd extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
      *
      *     @var string $name reaction (emoji) name
      *     @var string $file_comment file comment to add reaction to
-     *     @var float $timestamp timestamp of the message to add reaction to
+     *     @var string $timestamp timestamp of the message to add reaction to
      *     @var string $file file to add reaction to
      *     @var string $channel Channel where the message to add reaction to was posted.
      * }
@@ -65,7 +65,7 @@ class ReactionsAdd extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('name', ['string']);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/ReactionsGet.php
+++ b/generated/Endpoint/ReactionsGet.php
@@ -19,7 +19,7 @@ class ReactionsGet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
      *
      *     @var bool $full if true always return the complete reaction list
      *     @var string $file_comment file comment to get reactions for
-     *     @var float $timestamp timestamp of the message to get reactions for
+     *     @var string $timestamp timestamp of the message to get reactions for
      *     @var string $token Authentication token. Requires scope: `reactions:read`
      *     @var string $file file to get reactions for
      *     @var string $channel Channel where the message to get reactions for was posted.
@@ -60,7 +60,7 @@ class ReactionsGet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('full', ['bool']);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);

--- a/generated/Endpoint/ReactionsRemove.php
+++ b/generated/Endpoint/ReactionsRemove.php
@@ -19,7 +19,7 @@ class ReactionsRemove extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
      *
      *     @var string $name reaction (emoji) name
      *     @var string $file_comment file comment to remove reaction from
-     *     @var float $timestamp timestamp of the message to remove reaction from
+     *     @var string $timestamp timestamp of the message to remove reaction from
      *     @var string $file file to remove reaction from
      *     @var string $channel Channel where the message to remove reaction from was posted.
      * }
@@ -65,7 +65,7 @@ class ReactionsRemove extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('name', ['string']);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
 

--- a/generated/Endpoint/StarsAdd.php
+++ b/generated/Endpoint/StarsAdd.php
@@ -18,7 +18,7 @@ class StarsAdd extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to add star to
-     *     @var float $timestamp timestamp of the message to add star to
+     *     @var string $timestamp timestamp of the message to add star to
      *     @var string $channel channel to add star to, or channel where the message to add star to was posted (used with `timestamp`)
      *     @var string $file File to add star to.
      * }
@@ -63,7 +63,7 @@ class StarsAdd extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
 

--- a/generated/Endpoint/StarsRemove.php
+++ b/generated/Endpoint/StarsRemove.php
@@ -18,7 +18,7 @@ class StarsRemove extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      * @param array $formParameters {
      *
      *     @var string $file_comment file comment to remove star from
-     *     @var float $timestamp timestamp of the message to remove star from
+     *     @var string $timestamp timestamp of the message to remove star from
      *     @var string $channel channel to remove star from, or channel where the message to remove star from was posted (used with `timestamp`)
      *     @var string $file File to remove star from.
      * }
@@ -63,7 +63,7 @@ class StarsRemove extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('file_comment', ['string']);
-        $optionsResolver->setAllowedTypes('timestamp', ['float']);
+        $optionsResolver->setAllowedTypes('timestamp', ['string']);
         $optionsResolver->setAllowedTypes('channel', ['string']);
         $optionsResolver->setAllowedTypes('file', ['string']);
 

--- a/resources/patches/12-timestamp-types-pins-reactions-stars.patch
+++ b/resources/patches/12-timestamp-types-pins-reactions-stars.patch
@@ -1,0 +1,74 @@
+diff --git a/resources/slack-openapi-patched.json b/resources/slack-openapi-patched.json
+index 4b2c628..d167496 100644
+--- a/resources/slack-openapi-patched.json
++++ b/resources/slack-openapi-patched.json
+@@ -15761,7 +15761,7 @@
+                         "description": "Timestamp of the message to pin.",
+                         "in": "formData",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `pins:write`",
+@@ -16140,7 +16140,7 @@
+                         "description": "Timestamp of the message to un-pin.",
+                         "in": "formData",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `pins:write`",
+@@ -16280,7 +16280,7 @@
+                         "description": "Timestamp of the message to add reaction to.",
+                         "in": "formData",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `reactions:write`",
+@@ -16421,7 +16421,7 @@
+                         "description": "Timestamp of the message to get reactions for.",
+                         "in": "query",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `reactions:read`",
+@@ -16942,7 +16942,7 @@
+                         "description": "Timestamp of the message to remove reaction from.",
+                         "in": "formData",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `reactions:write`",
+@@ -18605,7 +18605,7 @@
+                         "description": "Timestamp of the message to add star to.",
+                         "in": "formData",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `stars:write`",
+@@ -18802,7 +18802,7 @@
+                         "description": "Timestamp of the message to remove star from.",
+                         "in": "formData",
+                         "name": "timestamp",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `stars:write`",
+@@ -22301,4 +22301,4 @@
+         }
+     },
+     "swagger": "2.0"
+-}
+\ No newline at end of file
++}

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -15761,7 +15761,7 @@
                         "description": "Timestamp of the message to pin.",
                         "in": "formData",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `pins:write`",
@@ -16140,7 +16140,7 @@
                         "description": "Timestamp of the message to un-pin.",
                         "in": "formData",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `pins:write`",
@@ -16280,7 +16280,7 @@
                         "description": "Timestamp of the message to add reaction to.",
                         "in": "formData",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `reactions:write`",
@@ -16421,7 +16421,7 @@
                         "description": "Timestamp of the message to get reactions for.",
                         "in": "query",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `reactions:read`",
@@ -16942,7 +16942,7 @@
                         "description": "Timestamp of the message to remove reaction from.",
                         "in": "formData",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `reactions:write`",
@@ -18605,7 +18605,7 @@
                         "description": "Timestamp of the message to add star to.",
                         "in": "formData",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `stars:write`",
@@ -18802,7 +18802,7 @@
                         "description": "Timestamp of the message to remove star from.",
                         "in": "formData",
                         "name": "timestamp",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `stars:write`",


### PR DESCRIPTION
Some endpoints that expect a timestamp to identify a message will not work with floats as the trailing zeroes are stripped when casting.

Passing strings with all microsecond digits will be accepted by the Slack API and restores functionality of those endpoints.