### PR TITLE
Request php-http/client-common in 1.9.0 min

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "jane-php/json-schema-runtime": "^4.5",
         "jane-php/open-api-runtime": "^4.5",
         "psr/http-client-implementation": "*",
-        "php-http/client-common": "^1.7 || 2.0"
+        "php-http/client-common": "^1.9 || 2.0"
     },
     "require-dev": {
         "jane-php/jane-php": "^4.5",


### PR DESCRIPTION
`php-http/client-common` introduced support for PSR-18 HTTP clients in version [1.9.0](https://github.com/php-http/client-common/blob/master/CHANGELOG.md#190---2019-01-03)