### PR TITLE
Throw exception when Slack returns error code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ composer.phar
 
 # CS
 .php_cs.cache
+phpunit.xml
 
 # tests
 generated_ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not yet released
 
 * Fix api.test endpoint
+* Throw exception when Slack returns error code
 
 ## 2.1.1 (2019-10-05)
 

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
         "jane-php/json-schema-runtime": "^4.5",
         "jane-php/open-api-runtime": "^4.5",
         "psr/http-client-implementation": "*",
-        "php-http/client-common": "^1.9 || 2.0",
+        "php-http/client-common": "^1.9 || ^2.0",
         "php-http/discovery": "^1.7"
     },
     "require-dev": {
         "jane-php/jane-php": "^4.5",
-        "symfony/http-client": "^4.3",
+        "symfony/http-client": "^4.3.3",
         "nyholm/psr7": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.13",
         "symfony/phpunit-bridge": "^4.3"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <!--<server name="SLACK_TOKEN" value="edit_me" />-->
     </php>
 
     <testsuites>

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -18,6 +18,7 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use JoliCode\Slack\Api\Client;
 use JoliCode\Slack\HttpPlugin\AddSlackPathAndHostPlugin;
+use JoliCode\Slack\HttpPlugin\SlackErrorPlugin;
 use Psr\Http\Client\ClientInterface;
 
 class ClientFactory
@@ -33,6 +34,7 @@ class ClientFactory
         $uri = Psr17FactoryDiscovery::findUrlFactory()->createUri('https://slack.com/api');
         $pluginClient = new PluginClient($httpClient, [
             new ErrorPlugin(),
+            new SlackErrorPlugin(),
             new AddSlackPathAndHostPlugin($uri),
             new HeaderAppendPlugin([
                 'Authorization' => 'Bearer '.$token,

--- a/src/Exception/SlackErrorResponse.php
+++ b/src/Exception/SlackErrorResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of JoliCode's Slack PHP API project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\Slack\Exception;
+
+class SlackErrorResponse extends \Exception
+{
+    private $errorCode;
+
+    public function __construct(string $errorCode, \Throwable $previous = null)
+    {
+        $this->errorCode = $errorCode;
+
+        parent::__construct(sprintf('Slack returned error code "%s"', $errorCode), 0, $previous);
+    }
+
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+}

--- a/src/HttpPlugin/SlackErrorPlugin.php
+++ b/src/HttpPlugin/SlackErrorPlugin.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of JoliCode's Slack PHP API project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\Slack\HttpPlugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use JoliCode\Slack\Exception\SlackErrorResponse;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class SlackErrorPlugin implements Plugin
+{
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $promise = $next($request);
+
+        return $promise->then(function (ResponseInterface $response) use ($request) {
+            $body = $response->getBody()->getContents();
+            $data = json_decode($body, true);
+
+            if (empty($data) || (isset($data['ok']) && $data['ok'] && empty($data['error']))) {
+                return $response;
+            }
+
+            throw new SlackErrorResponse($data['error']);
+        });
+    }
+}

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -12,6 +12,7 @@
 namespace JoliCode\Slack\Tests;
 
 use JoliCode\Slack\Api\Model\ApiTestGetResponse200;
+use JoliCode\Slack\Api\Model\UsersListGetResponse200;
 use JoliCode\Slack\ClientFactory;
 use JoliCode\Slack\Exception\SlackErrorResponse;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,7 @@ class FunctionalTest extends TestCase
         self::assertTrue($response->getOk());
     }
 
-    public function testItWorksOnTestError()
+    public function testItThrowsExceptionOnTestError()
     {
         $client = ClientFactory::create('');
 
@@ -37,5 +38,27 @@ class FunctionalTest extends TestCase
         $client->apiTest([
             'error' => 'yolo',
         ]);
+    }
+
+    public function testItWorksOnUserListWithCorrectToken()
+    {
+        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+
+        $response = $client->usersList();
+
+        self::assertInstanceOf(UsersListGetResponse200::class, $response);
+        self::assertTrue($response->getOk());
+
+        self::assertGreaterThan(2, \count($response->getMembers()));
+    }
+
+    public function testItThrowsExceptionOnUserListWithoutToken()
+    {
+        $client = ClientFactory::create('');
+
+        self::expectException(SlackErrorResponse::class);
+        self::expectExceptionMessage('Slack returned error code "not_authed"');
+
+        $client->usersList();
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -13,6 +13,7 @@ namespace JoliCode\Slack\Tests;
 
 use JoliCode\Slack\Api\Model\ApiTestGetResponse200;
 use JoliCode\Slack\ClientFactory;
+use JoliCode\Slack\Exception\SlackErrorResponse;
 use PHPUnit\Framework\TestCase;
 
 class FunctionalTest extends TestCase
@@ -29,11 +30,12 @@ class FunctionalTest extends TestCase
     public function testItWorksOnTestError()
     {
         $client = ClientFactory::create('');
-        $response = $client->apiTest([
+
+        self::expectException(SlackErrorResponse::class);
+        self::expectExceptionMessage('Slack returned error code "yolo"');
+
+        $client->apiTest([
             'error' => 'yolo',
         ]);
-
-        self::assertInstanceOf(ApiTestGetResponse200::class, $response);
-        self::assertFalse($response->getOk());
     }
 }


### PR DESCRIPTION
Attempt at fixing #7 

Slack documentation (https://api.slack.com/web) says :

> All Web API responses contain a JSON object, which will always contain a top-level boolean property `ok`, indicating success or failure.
>
> For failure results, the `error` property will contain a short machine-readable error code. In the case of problematic calls that could still be completed successfully, `ok` will be `true` and the `warning` property will contain a short machine-readable warning code (or comma-separated list of them, in the case of multiple warnings).

I propose to throw an exception when Slack returns `false` in `ok` and provides an `error` property.
I'm not a big fan of doing an additional `json_decode` for all calls, but I don't see much alternatives :confused: 
