### PR TITLE
Add missing parameters on `usergroups.users.list` API method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## Unreleased
+
+* **Specification override** The `usergroups.users.list` was missing parameters, fix #57
+
 ## 2.1.2 (2019-10-09)
 
 * Fix api.test endpoint

--- a/generated/Client.php
+++ b/generated/Client.php
@@ -2678,13 +2678,22 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
     }
 
     /**
+     * List all users in a User Group.
+     *
+     * @param array $queryParameters {
+     *
+     *     @var string $token Authentication token. Requires scope: `usergroups:read`
+     *     @var bool $include_disabled allow results that involve disabled User Groups
+     *     @var string $usergroup The encoded ID of the User Group to read.
+     * }
+     *
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
      * @return \JoliCode\Slack\Api\Model\UsergroupsUsersListGetResponse200|\JoliCode\Slack\Api\Model\UsergroupsUsersListGetResponsedefault|\Psr\Http\Message\ResponseInterface|null
      */
-    public function usergroupsUsersList(string $fetch = self::FETCH_OBJECT)
+    public function usergroupsUsersList(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
-        return $this->executePsr7Endpoint(new \JoliCode\Slack\Api\Endpoint\UsergroupsUsersList(), $fetch);
+        return $this->executePsr7Endpoint(new \JoliCode\Slack\Api\Endpoint\UsergroupsUsersList($queryParameters), $fetch);
     }
 
     /**

--- a/generated/Endpoint/UsergroupsUsersList.php
+++ b/generated/Endpoint/UsergroupsUsersList.php
@@ -12,6 +12,21 @@ namespace JoliCode\Slack\Api\Endpoint;
 
 class UsergroupsUsersList extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
 {
+    /**
+     * List all users in a User Group.
+     *
+     * @param array $queryParameters {
+     *
+     *     @var string $token Authentication token. Requires scope: `usergroups:read`
+     *     @var bool $include_disabled allow results that involve disabled User Groups
+     *     @var string $usergroup The encoded ID of the User Group to read.
+     * }
+     */
+    public function __construct(array $queryParameters = [])
+    {
+        $this->queryParameters = $queryParameters;
+    }
+
     use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
 
     public function getMethod(): string
@@ -32,6 +47,19 @@ class UsergroupsUsersList extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
     public function getExtraHeaders(): array
     {
         return ['Accept' => ['application/json']];
+    }
+
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['token', 'include_disabled', 'usergroup']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->setAllowedTypes('token', ['string']);
+        $optionsResolver->setAllowedTypes('include_disabled', ['bool']);
+        $optionsResolver->setAllowedTypes('usergroup', ['string']);
+
+        return $optionsResolver;
     }
 
     /**

--- a/resources/patches/06-usergroup-userlist-parameters.patch
+++ b/resources/patches/06-usergroup-userlist-parameters.patch
@@ -1,0 +1,30 @@
+--- resources/slack-openapi-patched.json
++++ resources/slack-openapi-patched.json
+@@ -21624,7 +21624,26 @@
+                     "url": "https://api.slack.com/methods/usergroups.users.list"
+                 },
+                 "operationId": "usergroups_users_list",
+-                "parameters": [],
++                "parameters": [
++                    {
++                        "description": "Authentication token. Requires scope: `usergroups:read`",
++                        "in": "query",
++                        "name": "token",
++                        "type": "string"
++                    },
++                    {
++                        "description": "Allow results that involve disabled User Groups.",
++                        "in": "query",
++                        "name": "include_disabled",
++                        "type": "boolean"
++                    },
++                    {
++                        "description": "The encoded ID of the User Group to read.",
++                        "in": "query",
++                        "name": "usergroup",
++                        "type": "string"
++                    }
++                ],
+                 "produces": [
+                     "application/json"
+                 ],

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -21624,7 +21624,26 @@
                     "url": "https://api.slack.com/methods/usergroups.users.list"
                 },
                 "operationId": "usergroups_users_list",
-                "parameters": [],
+                "parameters": [
+                    {
+                        "description": "Authentication token. Requires scope: `usergroups:read`",
+                        "in": "query",
+                        "name": "token",
+                        "type": "string"
+                    },
+                    {
+                        "description": "Allow results that involve disabled User Groups.",
+                        "in": "query",
+                        "name": "include_disabled",
+                        "type": "boolean"
+                    },
+                    {
+                        "description": "The encoded ID of the User Group to read.",
+                        "in": "query",
+                        "name": "usergroup",
+                        "type": "string"
+                    }
+                ],
                 "produces": [
                     "application/json"
                 ],


### PR DESCRIPTION
This patch fix issue #57 by adding the missing parameters to the Slack Specification.

@JakeBooher Could you test it with your project?