### PR TITLE
removed call to a dummy TestCommand class

### DIFF
--- a/bin/slack-api-client-generator
+++ b/bin/slack-api-client-generator
@@ -5,7 +5,6 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 use JoliCode\Slack\Command\CheckerCommand;
 use JoliCode\Slack\Command\GeneratePatchCommand;
-use JoliCode\Slack\Command\TestCommand;
 use JoliCode\Slack\Command\UpdateSpecificationCommand;
 use Symfony\Component\Console\Application;
 
@@ -13,5 +12,4 @@ $application = new Application();
 $application->add(new CheckerCommand());
 $application->add(new GeneratePatchCommand());
 $application->add(new UpdateSpecificationCommand());
-$application->add(new TestCommand());
 $application->run();


### PR DESCRIPTION
This is a hotfix for a bug introduced in #85 - see commit [ec51499](https://github.com/jolicode/slack-php-api/pull/85/commits/ec51499a3808134b5b5c23805bccf35f2bc39afb#diff-8018e40707d671ff8e4f4616eb713628R8)