### PR TITLE
Change "ts" from number to string as specification is wrong

### DIFF
--- a/generated/Client.php
+++ b/generated/Client.php
@@ -2148,7 +2148,7 @@ class Client extends \JoliCode\Slack\Api\Runtime\Client\Client
      * @param array $formParameters {
      *
      *     @var string $channel channel or conversation to set the read cursor for
-     *     @var float $ts Unique identifier of message you want marked as most recently seen in this conversation.
+     *     @var string $ts Unique identifier of message you want marked as most recently seen in this conversation.
      * }
      *
      * @param array $headerParameters {

--- a/generated/Endpoint/ConversationsMark.php
+++ b/generated/Endpoint/ConversationsMark.php
@@ -23,7 +23,7 @@ class ConversationsMark extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint 
      * @param array $formParameters {
      *
      *     @var string $channel channel or conversation to set the read cursor for
-     *     @var float $ts Unique identifier of message you want marked as most recently seen in this conversation.
+     *     @var string $ts Unique identifier of message you want marked as most recently seen in this conversation.
      * }
      *
      * @param array $headerParameters {
@@ -69,7 +69,7 @@ class ConversationsMark extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint 
         $optionsResolver->setRequired([]);
         $optionsResolver->setDefaults([]);
         $optionsResolver->setAllowedTypes('channel', ['string']);
-        $optionsResolver->setAllowedTypes('ts', ['float']);
+        $optionsResolver->setAllowedTypes('ts', ['string']);
 
         return $optionsResolver;
     }

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -12686,7 +12686,7 @@
                         "description": "Unique identifier of message you want marked as most recently seen in this conversation.",
                         "in": "formData",
                         "name": "ts",
-                        "type": "number"
+                        "type": "string"
                     }
                 ],
                 "produces": [
@@ -16041,6 +16041,7 @@
                                 "error": {
                                     "enum": [
                                         "account_inactive",
+                                        "file_upload_size_restricted",
                                         "file_uploads_disabled",
                                         "file_uploads_except_images_disabled",
                                         "invalid_arg_name",

--- a/resources/slack-openapi-sorted.json
+++ b/resources/slack-openapi-sorted.json
@@ -16010,6 +16010,7 @@
                                 "error": {
                                     "enum": [
                                         "account_inactive",
+                                        "file_upload_size_restricted",
                                         "file_uploads_disabled",
                                         "file_uploads_except_images_disabled",
                                         "invalid_arg_name",

--- a/resources/slack-openapi-sorted.patch
+++ b/resources/slack-openapi-sorted.patch
@@ -1,5 +1,5 @@
---- resources/slack-openapi-sorted.json	2020-10-21 09:45:29.539363011 +0200
-+++ resources/slack-openapi-patched.json	2020-10-21 10:14:27.338439082 +0200
+--- resources/slack-openapi-sorted.json	2020-11-22 19:07:43.855900105 +0100
++++ resources/slack-openapi-patched.json	2020-11-22 19:20:36.996043162 +0100
 @@ -507,20 +507,21 @@
                      "type": "boolean"
                  },
@@ -2482,6 +2482,29 @@
                                  "ok",
                                  "pin_count"
                              ],
+@@ -12655,21 +12679,21 @@
+                     {
+                         "description": "Authentication token. Requires scope: `conversations:write`",
+                         "in": "header",
+                         "name": "token",
+                         "type": "string"
+                     },
+                     {
+                         "description": "Unique identifier of message you want marked as most recently seen in this conversation.",
+                         "in": "formData",
+                         "name": "ts",
+-                        "type": "number"
++                        "type": "string"
+                     }
+                 ],
+                 "produces": [
+                     "application/json"
+                 ],
+                 "responses": {
+                     "200": {
+                         "description": "Typical success response",
+                         "schema": {
+                             "additionalProperties": false,
 @@ -13252,21 +13276,21 @@
                      {
                          "description": "Authentication token. Requires scope: `conversations:history`",

--- a/resources/slack-openapi.json
+++ b/resources/slack-openapi.json
@@ -16558,6 +16558,7 @@
                                         "posting_to_general_channel_denied",
                                         "invalid_channel",
                                         "file_uploads_disabled",
+                                        "file_upload_size_restricted",
                                         "file_uploads_except_images_disabled",
                                         "storage_limit_reached",
                                         "not_authed",

--- a/tests/WritingTest.php
+++ b/tests/WritingTest.php
@@ -124,4 +124,26 @@ class WritingTest extends TestCase
 
         $this->assertTrue($response->getOk());
     }
+
+    public function testItCanMarkConversation()
+    {
+        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+
+        $response = $client->chatPostMessage([
+            'username' => 'User A',
+            'channel' => $_SERVER['SLACK_TEST_CHANNEL'],
+            'text' => 'Message to be mark as read',
+        ]);
+
+        self::assertInstanceOf(ChatPostMessagePostResponse200::class, $response);
+
+        $ts = $response->getTs();
+
+        $markResponse = $client->conversationsMark([
+            'channel' => $_SERVER['SLACK_TEST_CHANNEL'],
+            'ts' => $ts,
+        ]);
+
+        self::assertTrue($markResponse->getOk());
+    }
 }


### PR DESCRIPTION
This is a fix for an error introduced here: https://github.com/jolicode/slack-php-api/pull/96#discussion_r510188600

The specification tells to send a number but a string is accepted and is the returned format in message responses.

A new `file_upload_size_restricted` enum string has been added by slack too.