### PR TITLE
Fixes remaining "ts" parameters from number to string type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 
 # tests
 generated_ci
+.phpunit.result.cache

--- a/generated/Client.php
+++ b/generated/Client.php
@@ -1996,9 +1996,9 @@ class Client extends \JoliCode\Slack\Api\Runtime\Client\Client
      *     @var string $channel conversation ID to fetch history for
      *     @var string $cursor Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.
      *     @var bool $inclusive include messages with latest or oldest timestamp in results only when either timestamp is specified
-     *     @var float $latest end of time range of messages to include in results
+     *     @var string $latest end of time range of messages to include in results
      *     @var int $limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
-     *     @var float $oldest start of time range of messages to include in results
+     *     @var string $oldest start of time range of messages to include in results
      *     @var string $token Authentication token. Requires scope: `conversations:history`
      * }
      *
@@ -2240,9 +2240,9 @@ class Client extends \JoliCode\Slack\Api\Runtime\Client\Client
      *     @var string $channel conversation ID to fetch thread from
      *     @var string $cursor Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.
      *     @var bool $inclusive include messages with latest or oldest timestamp in results only when either timestamp is specified
-     *     @var float $latest end of time range of messages to include in results
+     *     @var string $latest end of time range of messages to include in results
      *     @var int $limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
-     *     @var float $oldest start of time range of messages to include in results
+     *     @var string $oldest start of time range of messages to include in results
      *     @var string $token Authentication token. Requires scope: `conversations:history`
      *     @var string $ts Unique identifier of a thread's parent message. `ts` must be the timestamp of an existing message with 0 or more replies. If there are no replies then just the single message referenced by `ts` will return - it is just an ordinary, unthreaded message.
      * }
@@ -2595,8 +2595,8 @@ class Client extends \JoliCode\Slack\Api\Runtime\Client\Client
      *     @var string $cursor Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.
      *     @var int $limit the maximum number of items to return
      *     @var string $token Authentication token. Requires scope: `remote_files:read`
-     *     @var float $ts_from filter files created after this timestamp (inclusive)
-     *     @var float $ts_to Filter files created before this timestamp (inclusive).
+     *     @var string $ts_from filter files created after this timestamp (inclusive)
+     *     @var string $ts_to Filter files created before this timestamp (inclusive).
      * }
      *
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)

--- a/generated/Endpoint/ConversationsHistory.php
+++ b/generated/Endpoint/ConversationsHistory.php
@@ -25,9 +25,9 @@ class ConversationsHistory extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoi
      *     @var string $channel conversation ID to fetch history for
      *     @var string $cursor Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.
      *     @var bool $inclusive include messages with latest or oldest timestamp in results only when either timestamp is specified
-     *     @var float $latest end of time range of messages to include in results
+     *     @var string $latest end of time range of messages to include in results
      *     @var int $limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
-     *     @var float $oldest start of time range of messages to include in results
+     *     @var string $oldest start of time range of messages to include in results
      *     @var string $token Authentication token. Requires scope: `conversations:history`
      * }
      */
@@ -70,9 +70,9 @@ class ConversationsHistory extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoi
         $optionsResolver->setAllowedTypes('channel', ['string']);
         $optionsResolver->setAllowedTypes('cursor', ['string']);
         $optionsResolver->setAllowedTypes('inclusive', ['bool']);
-        $optionsResolver->setAllowedTypes('latest', ['float']);
+        $optionsResolver->setAllowedTypes('latest', ['string']);
         $optionsResolver->setAllowedTypes('limit', ['int']);
-        $optionsResolver->setAllowedTypes('oldest', ['float']);
+        $optionsResolver->setAllowedTypes('oldest', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
 
         return $optionsResolver;

--- a/generated/Endpoint/ConversationsReplies.php
+++ b/generated/Endpoint/ConversationsReplies.php
@@ -25,9 +25,9 @@ class ConversationsReplies extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoi
      *     @var string $channel conversation ID to fetch thread from
      *     @var string $cursor Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.
      *     @var bool $inclusive include messages with latest or oldest timestamp in results only when either timestamp is specified
-     *     @var float $latest end of time range of messages to include in results
+     *     @var string $latest end of time range of messages to include in results
      *     @var int $limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
-     *     @var float $oldest start of time range of messages to include in results
+     *     @var string $oldest start of time range of messages to include in results
      *     @var string $token Authentication token. Requires scope: `conversations:history`
      *     @var string $ts Unique identifier of a thread's parent message. `ts` must be the timestamp of an existing message with 0 or more replies. If there are no replies then just the single message referenced by `ts` will return - it is just an ordinary, unthreaded message.
      * }
@@ -71,9 +71,9 @@ class ConversationsReplies extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoi
         $optionsResolver->setAllowedTypes('channel', ['string']);
         $optionsResolver->setAllowedTypes('cursor', ['string']);
         $optionsResolver->setAllowedTypes('inclusive', ['bool']);
-        $optionsResolver->setAllowedTypes('latest', ['float']);
+        $optionsResolver->setAllowedTypes('latest', ['string']);
         $optionsResolver->setAllowedTypes('limit', ['int']);
-        $optionsResolver->setAllowedTypes('oldest', ['float']);
+        $optionsResolver->setAllowedTypes('oldest', ['string']);
         $optionsResolver->setAllowedTypes('token', ['string']);
         $optionsResolver->setAllowedTypes('ts', ['string']);
 

--- a/generated/Endpoint/FilesRemoteList.php
+++ b/generated/Endpoint/FilesRemoteList.php
@@ -26,8 +26,8 @@ class FilesRemoteList extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint im
      *     @var string $cursor Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.
      *     @var int $limit the maximum number of items to return
      *     @var string $token Authentication token. Requires scope: `remote_files:read`
-     *     @var float $ts_from filter files created after this timestamp (inclusive)
-     *     @var float $ts_to Filter files created before this timestamp (inclusive).
+     *     @var string $ts_from filter files created after this timestamp (inclusive)
+     *     @var string $ts_to Filter files created before this timestamp (inclusive).
      * }
      */
     public function __construct(array $queryParameters = [])
@@ -70,8 +70,8 @@ class FilesRemoteList extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint im
         $optionsResolver->setAllowedTypes('cursor', ['string']);
         $optionsResolver->setAllowedTypes('limit', ['int']);
         $optionsResolver->setAllowedTypes('token', ['string']);
-        $optionsResolver->setAllowedTypes('ts_from', ['float']);
-        $optionsResolver->setAllowedTypes('ts_to', ['float']);
+        $optionsResolver->setAllowedTypes('ts_from', ['string']);
+        $optionsResolver->setAllowedTypes('ts_to', ['string']);
 
         return $optionsResolver;
     }

--- a/generated/Model/ObjsComment.php
+++ b/generated/Model/ObjsComment.php
@@ -52,7 +52,7 @@ class ObjsComment
      */
     protected $reactions;
     /**
-     * @var string|int|null
+     * @var int|string|null
      */
     protected $timestamp;
     /**
@@ -187,7 +187,7 @@ class ObjsComment
     }
 
     /**
-     * @return string|int|null
+     * @return int|string|null
      */
     public function getTimestamp()
     {
@@ -195,7 +195,7 @@ class ObjsComment
     }
 
     /**
-     * @param string|int|null $timestamp
+     * @param int|string|null $timestamp
      */
     public function setTimestamp($timestamp): self
     {

--- a/generated/Model/ObjsFile.php
+++ b/generated/Model/ObjsFile.php
@@ -276,7 +276,7 @@ class ObjsFile
      */
     protected $thumbTiny;
     /**
-     * @var string|int|null
+     * @var int|string|null
      */
     protected $timestamp;
     /**
@@ -1125,7 +1125,7 @@ class ObjsFile
     }
 
     /**
-     * @return string|int|null
+     * @return int|string|null
      */
     public function getTimestamp()
     {
@@ -1133,7 +1133,7 @@ class ObjsFile
     }
 
     /**
-     * @param string|int|null $timestamp
+     * @param int|string|null $timestamp
      */
     public function setTimestamp($timestamp): self
     {

--- a/generated/Normalizer/ObjsCommentNormalizer.php
+++ b/generated/Normalizer/ObjsCommentNormalizer.php
@@ -105,9 +105,9 @@ class ObjsCommentNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         if (\array_key_exists('timestamp', $data) && null !== $data['timestamp']) {
             $value_2 = $data['timestamp'];
-            if (\is_string($data['timestamp'])) {
+            if (\is_int($data['timestamp'])) {
                 $value_2 = $data['timestamp'];
-            } elseif (\is_int($data['timestamp'])) {
+            } elseif (\is_string($data['timestamp'])) {
                 $value_2 = $data['timestamp'];
             }
             $object->setTimestamp($value_2);
@@ -154,9 +154,9 @@ class ObjsCommentNormalizer implements DenormalizerInterface, NormalizerInterfac
             $data['reactions'] = $values_1;
         }
         $value_2 = $object->getTimestamp();
-        if (\is_string($object->getTimestamp())) {
+        if (\is_int($object->getTimestamp())) {
             $value_2 = $object->getTimestamp();
-        } elseif (\is_int($object->getTimestamp())) {
+        } elseif (\is_string($object->getTimestamp())) {
             $value_2 = $object->getTimestamp();
         }
         $data['timestamp'] = $value_2;

--- a/generated/Normalizer/ObjsFileNormalizer.php
+++ b/generated/Normalizer/ObjsFileNormalizer.php
@@ -397,9 +397,9 @@ class ObjsFileNormalizer implements DenormalizerInterface, NormalizerInterface, 
         }
         if (\array_key_exists('timestamp', $data) && null !== $data['timestamp']) {
             $value_5 = $data['timestamp'];
-            if (\is_string($data['timestamp'])) {
+            if (\is_int($data['timestamp'])) {
                 $value_5 = $data['timestamp'];
-            } elseif (\is_int($data['timestamp'])) {
+            } elseif (\is_string($data['timestamp'])) {
                 $value_5 = $data['timestamp'];
             }
             $object->setTimestamp($value_5);
@@ -665,9 +665,9 @@ class ObjsFileNormalizer implements DenormalizerInterface, NormalizerInterface, 
         }
         if (null !== $object->getTimestamp()) {
             $value_5 = $object->getTimestamp();
-            if (\is_string($object->getTimestamp())) {
+            if (\is_int($object->getTimestamp())) {
                 $value_5 = $object->getTimestamp();
-            } elseif (\is_int($object->getTimestamp())) {
+            } elseif (\is_string($object->getTimestamp())) {
                 $value_5 = $object->getTimestamp();
             }
             $data['timestamp'] = $value_5;

--- a/generated/Runtime/Client/BaseEndpoint.php
+++ b/generated/Runtime/Client/BaseEndpoint.php
@@ -38,7 +38,7 @@ abstract class BaseEndpoint implements Endpoint
             return null !== $value ? $value : '';
         }, $optionsResolved);
 
-        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+        return http_build_query($optionsResolved, '', '&', \PHP_QUERY_RFC3986);
     }
 
     public function getHeaders(array $baseHeaders = []): array

--- a/generated/Runtime/Normalizer/CheckArray.php
+++ b/generated/Runtime/Normalizer/CheckArray.php
@@ -19,6 +19,6 @@ trait CheckArray
     {
         return \count(array_filter($array, function ($key) {
             return is_numeric($key);
-        }, ARRAY_FILTER_USE_KEY)) === \count($array);
+        }, \ARRAY_FILTER_USE_KEY)) === \count($array);
     }
 }

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -11654,7 +11654,7 @@
                         "description": "End of time range of messages to include in results.",
                         "in": "query",
                         "name": "latest",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
@@ -11666,7 +11666,7 @@
                         "description": "Start of time range of messages to include in results.",
                         "in": "query",
                         "name": "oldest",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `conversations:history`",
@@ -13265,7 +13265,7 @@
                         "description": "End of time range of messages to include in results.",
                         "in": "query",
                         "name": "latest",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
@@ -13277,7 +13277,7 @@
                         "description": "Start of time range of messages to include in results.",
                         "in": "query",
                         "name": "oldest",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Authentication token. Requires scope: `conversations:history`",
@@ -15371,13 +15371,13 @@
                         "description": "Filter files created after this timestamp (inclusive).",
                         "in": "query",
                         "name": "ts_from",
-                        "type": "number"
+                        "type": "string"
                     },
                     {
                         "description": "Filter files created before this timestamp (inclusive).",
                         "in": "query",
                         "name": "ts_to",
-                        "type": "number"
+                        "type": "string"
                     }
                 ],
                 "produces": [

--- a/resources/slack-openapi-sorted.patch
+++ b/resources/slack-openapi-sorted.patch
@@ -1,5 +1,5 @@
---- resources/slack-openapi-sorted.json	2020-12-28 10:01:25.748286602 +0100
-+++ resources/slack-openapi-patched.json	2020-12-28 11:16:51.785253670 +0100
+--- resources/slack-openapi-sorted.json	2021-02-24 15:12:58.000000000 -0700
++++ resources/slack-openapi-patched.json	2021-02-24 15:16:56.000000000 -0700
 @@ -397,21 +397,24 @@
                      },
                      "type": "array"
@@ -2501,6 +2501,42 @@
                          "type": "string"
                      }
                  ],
+@@ -11629,33 +11647,33 @@
+                     {
+                         "description": "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
+                         "in": "query",
+                         "name": "inclusive",
+                         "type": "boolean"
+                     },
+                     {
+                         "description": "End of time range of messages to include in results.",
+                         "in": "query",
+                         "name": "latest",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+                         "in": "query",
+                         "name": "limit",
+                         "type": "integer"
+                     },
+                     {
+                         "description": "Start of time range of messages to include in results.",
+                         "in": "query",
+                         "name": "oldest",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Authentication token. Requires scope: `conversations:history`",
+                         "in": "query",
+                         "name": "token",
+                         "type": "string"
+                     }
+                 ],
+                 "produces": [
+                     "application/json"
 @@ -11689,20 +11707,32 @@
                                      },
                                      "minItems": 1,
@@ -2557,7 +2593,33 @@
                          "description": "Typical success response",
                          "schema": {
                              "additionalProperties": false,
-@@ -13252,21 +13282,21 @@
+@@ -13228,45 +13258,45 @@
+                     {
+                         "description": "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
+                         "in": "query",
+                         "name": "inclusive",
+                         "type": "boolean"
+                     },
+                     {
+                         "description": "End of time range of messages to include in results.",
+                         "in": "query",
+                         "name": "latest",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+                         "in": "query",
+                         "name": "limit",
+                         "type": "integer"
+                     },
+                     {
+                         "description": "Start of time range of messages to include in results.",
+                         "in": "query",
+                         "name": "oldest",
+-                        "type": "number"
++                        "type": "string"
+                     },
                      {
                          "description": "Authentication token. Requires scope: `conversations:history`",
                          "in": "query",
@@ -2776,6 +2838,36 @@
                      {
                          "description": "Filter files created by a single user.",
                          "in": "query",
+@@ -15327,27 +15364,27 @@
+                     {
+                         "description": "Authentication token. Requires scope: `remote_files:read`",
+                         "in": "query",
+                         "name": "token",
+                         "type": "string"
+                     },
+                     {
+                         "description": "Filter files created after this timestamp (inclusive).",
+                         "in": "query",
+                         "name": "ts_from",
+-                        "type": "number"
++                        "type": "string"
+                     },
+                     {
+                         "description": "Filter files created before this timestamp (inclusive).",
+                         "in": "query",
+                         "name": "ts_to",
+-                        "type": "number"
++                        "type": "string"
+                     }
+                 ],
+                 "produces": [
+                     "application/json"
+                 ],
+                 "responses": {
+                     "200": {
+                         "description": "Typical success response",
+                         "schema": {
+                             "additionalProperties": true,
 @@ -15901,21 +15938,21 @@
                      }
                  ],


### PR DESCRIPTION
Fixes remaining "ts" parameters from `number` type to `string` type. Similar issues reported for other parameters in #12, #22, #26, #27, and #75. Also adds the phpunit result cache file to gitignore list.