### PR TITLE
Upgrade JanePHP and rebuild the classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Upgrade Jane to from 6.3.3 to v6.3.5, fix an error with very long string / payload
+
 ## 4.1.0 (2021-02-26)
 
 * **Specification override** Fix some `timestamp` from integer to mixed string and integer to support old messages

--- a/generated/Runtime/Client/Client.php
+++ b/generated/Runtime/Client/Client.php
@@ -61,7 +61,8 @@ abstract class Client
                 $request = $request->withBody($body);
             } elseif (\is_resource($body)) {
                 $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
-            } elseif (is_file($body)) {
+            } elseif (\strlen($body) <= 4000 && is_file($body)) {
+                // more than 4096 chars will trigger an error
                 $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
             } else {
                 $request = $request->withBody($this->streamFactory->createStream($body));


### PR DESCRIPTION
In an attempt to fix #107 - JanePHP released a minor patch avoiding this kind of error: 

> Warning: is_file(): File name is longer than the maximum allowed path length on this platform (4096)

Example: https://3v4l.org/6SfuH

This PR upgrade JanePHP and regenerate the client with this fix. Thanks to @Korbeil for the JanePHP fix!