### PR TITLE
Change spec source to have examples embedded

### DIFF
--- a/doc/updating-sdk.md
+++ b/doc/updating-sdk.md
@@ -31,7 +31,6 @@ of the `generated` directory:
 rm -Rf generated/*
 ```
 
-
 When the versioned specification has been updated, you can run Jane to regenerate the SDK:
 
 ```bash

--- a/generated/Model/DndTeamInfoGetResponsedefault.php
+++ b/generated/Model/DndTeamInfoGetResponsedefault.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace JoliCode\Slack\Api\Model;
 
-class DndTeamInfoGetResponsedefault
+class DndTeamInfoGetResponsedefault extends \ArrayObject
 {
     /**
      * @var bool|null

--- a/generated/Normalizer/DndTeamInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DndTeamInfoGetResponsedefaultNormalizer.php
@@ -52,8 +52,14 @@ class DndTeamInfoGetResponsedefaultNormalizer implements DenormalizerInterface, 
         }
         if (\array_key_exists('ok', $data) && null !== $data['ok']) {
             $object->setOk($data['ok']);
+            unset($data['ok']);
         } elseif (\array_key_exists('ok', $data) && null === $data['ok']) {
             $object->setOk(null);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
         }
 
         return $object;
@@ -63,6 +69,11 @@ class DndTeamInfoGetResponsedefaultNormalizer implements DenormalizerInterface, 
     {
         $data = [];
         $data['ok'] = $object->getOk();
+        foreach ($object as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $data[$key] = $value;
+            }
+        }
 
         return $data;
     }

--- a/resources/slack-openapi-patched.json
+++ b/resources/slack-openapi-patched.json
@@ -2413,12 +2413,17 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
                             "properties": {
                                 "ok": {
-                                    "$ref": "#/definitions/defs_ok_false"
+                                    "$ref": "#/definitions/defs_ok_true"
                                 }
                             },
                             "required": [
@@ -2430,6 +2435,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2506,6 +2517,56 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "approved_apps": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://myteam.enterprise.slack.com/apps/A0W7UKG8E-my-test-app",
+                                            "app_homepage_url": "https://www.slack.com",
+                                            "description": "test app",
+                                            "help_url": "https://www.slack.com",
+                                            "icons": {
+                                                "image_1024": "https://3026743124446w96_2bd4ea1ad1f89a23c242_1024.png",
+                                                "image_128": "https://30267341249446w6_2bd4ea1ad1f89a23c242_128.png",
+                                                "image_192": "https://30267431249446w6_2bd4ea1ad1f89a23c242_192.png",
+                                                "image_32": "https://302674312496446w_2bd4ea1ad1f89a23c242_32.png",
+                                                "image_36": "https://302674312496446w_2bd4ea1ad1f89a23c242_36.png",
+                                                "image_48": "https://302674312496446w_2bd4ea1ad1f89a23c242_48.png",
+                                                "image_512": "https://30267431249446w6_2bd4ea1ad1f89a23c242_512.png",
+                                                "image_64": "https://302674312496446w_2bd4ea1ad1f89a23c242_64.png",
+                                                "image_72": "https://302674312496446w_2bd4ea1ad1f89a23c242_72.png",
+                                                "image_96": "https://302674312496446w_2bd4ea1ad1f89a23c242_96.png",
+                                                "image_original": "https://302674446w12496_2bd4ea1ad1f89a23c242_original.png"
+                                            },
+                                            "id": "A0W7UKG8E",
+                                            "is_app_directory_approved": false,
+                                            "is_internal": false,
+                                            "name": "My Test App",
+                                            "privacy_policy_url": "https://www.slack.com"
+                                        },
+                                        "date_updated": 1574296707,
+                                        "last_resolved_by": {
+                                            "actor_id": "W0G82F4FD",
+                                            "actor_type": "user"
+                                        },
+                                        "scopes": [
+                                            {
+                                                "description": "Add the ability for people to direct message or mention @my_test_app",
+                                                "is_sensitive": true,
+                                                "name": "bot",
+                                                "token_type": "bot"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2523,6 +2584,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2594,6 +2661,64 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "app_requests": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://acmecorp.slack.com/apps/A061BL8RQ0-test-app",
+                                            "app_homepage_url": "",
+                                            "description": "",
+                                            "help_url": "",
+                                            "icons": {
+                                                "image_1024": "/cdn/15258203/img/testapp/service_1024.png",
+                                                "image_128": "/cdn/157258203/img/testapp/service_128.png",
+                                                "image_192": "/cdn/157258203/img/testapp/service_192.png",
+                                                "image_32": "/cdn/157658203/img/testapp/service_32.png",
+                                                "image_36": "/cdn/157658203/img/testapp/service_36.png",
+                                                "image_48": "/cdn/157658203/img/testapp/service_48.png",
+                                                "image_512": "/cdn/15758203/img/testapp/service_512.png",
+                                                "image_64": "/cdn/157658203/img/testapp/service_64.png",
+                                                "image_72": "/cdn/157658203/img/testapp/service_72.png",
+                                                "image_96": "/cdn/157658203/img/testapp/service_96.png"
+                                            },
+                                            "id": "A061BL8RQ0",
+                                            "is_app_directory_approved": true,
+                                            "is_internal": false,
+                                            "name": "Test App",
+                                            "privacy_policy_url": "https://testapp.com/privacy"
+                                        },
+                                        "date_created": 1578956327,
+                                        "id": "Ar0XJGFLMLS",
+                                        "message": "test test again",
+                                        "previous_resolution": null,
+                                        "scopes": [
+                                            {
+                                                "description": "Post messages to specific channels in Slack",
+                                                "is_sensitive": false,
+                                                "name": "incoming-webhook",
+                                                "token_type": "user"
+                                            }
+                                        ],
+                                        "team": {
+                                            "domain": "acmecorp",
+                                            "id": "T0M94LNUCR",
+                                            "name": "Acme Corp"
+                                        },
+                                        "user": {
+                                            "email": "janedoe@example.com",
+                                            "id": "W08RA9G5HR",
+                                            "name": "Jane Doe"
+                                        }
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2611,6 +2736,14 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "missing_scope",
+                                "needed": "admin.apps:read",
+                                "ok": false,
+                                "provided": "read,client,admin,identify,post,apps"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2683,6 +2816,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2700,6 +2838,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2776,6 +2920,56 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                },
+                                "restricted_apps": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://myteam.enterprise.slack.com/apps/A0FDLP8M2L-my-test-app",
+                                            "app_homepage_url": "https://example.com",
+                                            "description": "A fun test app for Slack",
+                                            "help_url": "https://example.com",
+                                            "icons": {
+                                                "image_1024": "https://1433265338rl878408_eb57dbc818daa4ba15d6_1024.png",
+                                                "image_128": "https://4332653438rl87808_eb57dbc818daa4ba15d6_128.png",
+                                                "image_192": "https://4332653438rl87808_eb57dbc818daa4ba15d6_192.png",
+                                                "image_32": "https://143326534038rl8788_eb57dbc818daa4ba15d6_32.png",
+                                                "image_36": "https://143326534038rl8788_eb57dbc818daa4ba15d6_36.png",
+                                                "image_48": "https://143326534038rl8788_eb57dbc818daa4ba15d6_48.png",
+                                                "image_512": "https://4332653438rl87808_eb57dbc818daa4ba15d6_512.png",
+                                                "image_64": "https://143326534038rl8788_eb57dbc818daa4ba15d6_64.png",
+                                                "image_72": "https://143326534038rl8788_eb57dbc818daa4ba15d6_72.png",
+                                                "image_96": "https://143326534038rl8788_eb57dbc818daa4ba15d6_96.png",
+                                                "image_original": "https://143338rl8782653408_eb57dbc818daa4ba15d6_original.png"
+                                            },
+                                            "id": "A0FDLP8M2L",
+                                            "is_app_directory_approved": true,
+                                            "is_internal": false,
+                                            "name": "My Test App",
+                                            "privacy_policy_url": "https://example.com"
+                                        },
+                                        "date_updated": 1574296721,
+                                        "last_resolved_by": {
+                                            "actor_id": "W0G82LMFD",
+                                            "actor_type": "user"
+                                        },
+                                        "scopes": [
+                                            {
+                                                "description": "Upload, edit, and delete files on the user\u201fs behalf",
+                                                "is_sensitive": true,
+                                                "name": "files:write:user",
+                                                "token_type": "user"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2793,6 +2987,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2855,6 +3055,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.archive",
@@ -2872,6 +3077,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.archive",
@@ -2948,6 +3159,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.convertToPrivate",
@@ -2965,6 +3181,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.convertToPrivate",
@@ -3067,6 +3289,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel_id": "C12345",
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.create",
@@ -3087,6 +3315,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.create",
@@ -3163,6 +3397,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.delete",
@@ -3180,6 +3419,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.delete",
@@ -3262,6 +3507,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.disconnectShared",
@@ -3279,6 +3529,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.disconnectShared",
@@ -3376,6 +3632,19 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "id": "string",
+                                        "internal_team_ids": "array",
+                                        "original_connected_channel_id": "string",
+                                        "original_connected_host_id": "string"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3393,6 +3662,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3455,6 +3730,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.getConversationPrefs",
@@ -3511,6 +3791,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.getConversationPrefs",
@@ -3599,6 +3885,15 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "teams": [
+                                    "T1234",
+                                    "T5678"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.getTeams",
@@ -3635,6 +3930,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.getTeams",
@@ -3718,6 +4019,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.invite",
@@ -3735,6 +4041,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for error response from admin.conversations.invite",
@@ -3816,6 +4128,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.rename",
@@ -3833,6 +4150,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.rename",
@@ -3920,6 +4243,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3937,6 +4265,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4003,6 +4337,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "group_ids": [
+                                    "YOUR_GROUP_ID"
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4020,6 +4362,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4095,6 +4443,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4112,6 +4465,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4209,6 +4568,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.search",
@@ -4233,6 +4635,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_enterprise",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.search",
@@ -4318,6 +4726,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.setConversationPrefs",
@@ -4335,6 +4748,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.setConversationPrefs",
@@ -4429,6 +4848,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4446,6 +4870,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4508,6 +4938,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.unarchive",
@@ -4525,6 +4960,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.unarchive",
@@ -4607,6 +5048,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4624,6 +5070,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4692,6 +5144,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4709,6 +5166,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4775,6 +5238,43 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "cache_ts": "1575283387.000000",
+                                "categories": [
+                                    {
+                                        "emoji_names": [
+                                            "etc etc ...",
+                                            "grin",
+                                            "grinning",
+                                            "joy"
+                                        ],
+                                        "name": "Smileys & People"
+                                    }
+                                ],
+                                "categories_version": "5",
+                                "emoji": {
+                                    "black_square": "alias:black_large_square",
+                                    "bowtie": "https://emoji.slack-edge.com/T9TK3CUKW/bowtie/f3ec6f2bb0.png",
+                                    "cubimal_chick": "https://emoji.slack-edge.com/T9TK3CUKW/cubimal_chick/85961c43d7.png",
+                                    "dusty_stick": "https://emoji.slack-edge.com/T9TK3CUKW/dusty_stick/6177a62312.png",
+                                    "glitch_crab": "https://emoji.slack-edge.com/T9TK3CUKW/glitch_crab/db049f1f9c.png",
+                                    "piggy": "https://emoji.slack-edge.com/T9TK3CUKW/piggy/b7762ee8cd.png",
+                                    "pride": "https://emoji.slack-edge.com/T9TK3CUKW/pride/56b1bd3388.png",
+                                    "shipit": "alias:squirrel",
+                                    "simple_smile": {
+                                        "apple": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/apple/simple_smile.png",
+                                        "google": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/google/simple_smile.png"
+                                    },
+                                    "slack": "https://emoji.slack-edge.com/T9TK3CUKW/slack/7d462d2443.png",
+                                    "slack_call": "https://emoji.slack-edge.com/T9TK3CUKW/slack_call/b81fffd6dd.png",
+                                    "squirrel": "https://emoji.slack-edge.com/T9TK3CUKW/squirrel/465f40c0e0.png",
+                                    "thumbsup_all": "https://emoji.slack-edge.com/T9TK3CUKW/thumbsup_all/50096a1020.gif",
+                                    "white_square": "alias:white_large_square"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4792,6 +5292,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4853,6 +5359,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4870,6 +5381,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4938,6 +5455,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4955,6 +5477,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5023,6 +5551,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5040,6 +5573,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5113,6 +5652,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5130,6 +5674,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5203,6 +5753,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5220,6 +5775,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5288,6 +5849,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5305,6 +5871,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5378,6 +5950,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5395,6 +5972,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5467,6 +6050,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "admin_ids": [
+                                    "U1234"
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5484,6 +6075,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5565,6 +6162,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": "T12345"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5582,6 +6185,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5649,6 +6258,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "teams": [
+                                    {
+                                        "discoverability": "hidden",
+                                        "id": "T1234",
+                                        "name": "My Team",
+                                        "primary_owner": {
+                                            "email": "bront@slack.com",
+                                            "user_id": "W1234"
+                                        },
+                                        "team_url": "https://subarachnoid.slack.com/"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5666,6 +6292,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5738,6 +6370,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "owner_ids": [
+                                    "U1234"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5755,6 +6395,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5816,6 +6462,21 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "default_channels": "array",
+                                    "domain": "string",
+                                    "email_domain": "string",
+                                    "enterprise_id": "string",
+                                    "enterprise_name": "string",
+                                    "icon": "array",
+                                    "id": "string",
+                                    "name": "string"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5833,6 +6494,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5901,6 +6568,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5918,6 +6590,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5987,6 +6665,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6004,6 +6687,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6073,6 +6762,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6090,6 +6784,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6158,6 +6858,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6175,6 +6880,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6244,6 +6955,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6261,6 +6977,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6336,6 +7058,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6353,6 +7080,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6428,6 +7161,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6445,6 +7183,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6519,6 +7263,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "id": "C024BE91L",
+                                        "name": "fun",
+                                        "num_members": 34,
+                                        "team_id": "T024BE911"
+                                    },
+                                    {
+                                        "id": "C024BE91K",
+                                        "name": "more fun",
+                                        "team_id": "T024BE912"
+                                    },
+                                    {
+                                        "id": "C024BE91M",
+                                        "is_redacted": true,
+                                        "name": "public-channel",
+                                        "num_members": 34,
+                                        "team_id": "T024BE911"
+                                    },
+                                    {
+                                        "id": "C024BE91N",
+                                        "name": "some more fun",
+                                        "team_id": "T024BE921"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6536,6 +7310,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6605,6 +7385,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6622,6 +7407,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6709,6 +7500,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6726,6 +7522,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6838,6 +7640,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6855,6 +7662,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6929,6 +7742,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": [
+                                    {
+                                        "email": "bront@slack.com",
+                                        "id": "T1234",
+                                        "is_admin": false,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6946,6 +7776,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7015,6 +7851,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7032,6 +7873,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7100,6 +7947,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7117,6 +7969,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7191,6 +8049,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7208,6 +8071,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7277,6 +8146,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7294,6 +8168,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7370,6 +8250,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7387,6 +8272,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7456,6 +8347,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7473,6 +8369,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7542,6 +8444,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7559,6 +8466,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7620,6 +8533,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -7642,6 +8560,15 @@
                     },
                     "default": {
                         "description": "Artificial error response",
+                        "examples": {
+                            "application/json": {
+                                "args": {
+                                    "error": "my_error"
+                                },
+                                "error": "my_error",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -7721,6 +8648,17 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "authorizations": {
+                                    "enterprise_id": "string",
+                                    "is_bot": "string",
+                                    "team_id": "string",
+                                    "user_id": "string"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7738,6 +8676,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7792,6 +8736,62 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "info": {
+                                    "app_home": {
+                                        "resources": {
+                                            "ids": [
+                                                "D0BH95DLH",
+                                                "D0C0NU1Q8"
+                                            ]
+                                        },
+                                        "scopes": [
+                                            "chat:write",
+                                            "im:history",
+                                            "im:read"
+                                        ]
+                                    },
+                                    "channel": {
+                                        "resources": {
+                                            "excluded_ids": [],
+                                            "ids": [
+                                                "C061FA5PB"
+                                            ],
+                                            "wildcard": false
+                                        },
+                                        "scopes": [
+                                            "channels:read"
+                                        ]
+                                    },
+                                    "group": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "im": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "mpim": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "team": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    }
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.permissions.info method",
@@ -7893,6 +8893,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.info method",
@@ -7990,6 +8996,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.permissions.request method",
@@ -8007,6 +9018,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when trigger_id is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_trigger_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.request method",
@@ -8106,6 +9123,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "resources": [
+                                    {
+                                        "id": "T0DES3UAN",
+                                        "type": "team"
+                                    },
+                                    {
+                                        "id": "D024BFF1M",
+                                        "type": "app_home"
+                                    },
+                                    {
+                                        "id": "C024BE91L",
+                                        "type": "channel"
+                                    }
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response apps.permissions.resources.list method",
@@ -8164,6 +9203,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.resources.list method",
@@ -8248,6 +9293,35 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "scopes": {
+                                    "app_home": [
+                                        "chat:write",
+                                        "im:history",
+                                        "im:read"
+                                    ],
+                                    "channel": [
+                                        "channels:history",
+                                        "chat:write"
+                                    ],
+                                    "group": [
+                                        "chat:write"
+                                    ],
+                                    "im": [
+                                        "chat:write"
+                                    ],
+                                    "mpim": [
+                                        "chat:write"
+                                    ],
+                                    "team": [
+                                        "users:read"
+                                    ],
+                                    "user": []
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response api.permissions.scopes.list method",
@@ -8293,6 +9367,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.scopes.list method",
@@ -8388,6 +9468,29 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "resources": [
+                                    {
+                                        "id": "U0DES3UAN",
+                                        "scopes": [
+                                            "dnd:write:user",
+                                            "reminders:write:user"
+                                        ]
+                                    },
+                                    {
+                                        "id": "U024BFF1M",
+                                        "scopes": [
+                                            "reminders:write:user"
+                                        ]
+                                    }
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTdPMUg5UkFTT0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8405,6 +9508,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8480,6 +9589,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8497,6 +9611,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when trigger_id is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_trigger_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8563,6 +9683,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.uninstall method",
@@ -8580,6 +9705,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.uninstall method",
@@ -8671,6 +9802,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "revoked": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from auth.revoke method",
@@ -8692,6 +9829,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from auth.revoke method",
@@ -8774,6 +9917,16 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": "Subarachnoid Workspace",
+                                "team_id": "T12345678",
+                                "url": "https://subarachnoid.slack.com/",
+                                "user": "grace",
+                                "user_id": "W12345678"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response auth.test method",
@@ -8817,6 +9970,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response auth.test method",
@@ -8900,6 +10059,24 @@
                 "responses": {
                     "200": {
                         "description": "When successful, returns bot info by bot ID.",
+                        "examples": {
+                            "application/json": {
+                                "bot": {
+                                    "app_id": "A161CLERW",
+                                    "deleted": false,
+                                    "icons": {
+                                        "image_36": "https://...",
+                                        "image_48": "https://...",
+                                        "image_72": "https://..."
+                                    },
+                                    "id": "B061F7JD2",
+                                    "name": "beforebot",
+                                    "updated": 1449272004,
+                                    "user_id": "U012ABCDEF"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from bots.info method",
@@ -8973,6 +10150,12 @@
                     },
                     "default": {
                         "description": "When no bot can be found, it returns an error.",
+                        "examples": {
+                            "application/json": {
+                                "error": "bot_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from bots.info method",
@@ -9106,6 +10289,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9123,6 +10311,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9190,6 +10384,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9207,6 +10406,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9268,6 +10473,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9285,6 +10495,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9353,6 +10569,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9370,6 +10591,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9439,6 +10666,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9456,6 +10688,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9536,6 +10774,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9553,6 +10796,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9625,6 +10874,13 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE91L",
+                                "ok": true,
+                                "ts": "1401383885.000061"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.delete method",
@@ -9650,6 +10906,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "message_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.delete method",
@@ -9756,6 +11018,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.deleteScheduledMessage method",
@@ -9773,6 +11040,12 @@
                     },
                     "default": {
                         "description": "Typical error response if no message is found",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_scheduled_message_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.deleteScheduledMessage method",
@@ -9874,6 +11147,13 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGA",
+                                "ok": true,
+                                "permalink": "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response chat.getPermalink",
@@ -9900,6 +11180,12 @@
                     },
                     "default": {
                         "description": "Error response when channel cannot be found",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.getPermalink method",
@@ -9996,6 +11282,13 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE7LR",
+                                "ok": true,
+                                "ts": "1417671948.000006"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.meMessage method",
@@ -10019,6 +11312,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.meMessage method",
@@ -10182,6 +11481,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "message_ts": "1502210682.580145",
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.postEphemeral method",
@@ -10203,6 +11508,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_in_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.postEphemeral method",
@@ -10384,6 +11695,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGL",
+                                "message": {
+                                    "attachments": [
+                                        {
+                                            "fallback": "This is an attachment's fallback",
+                                            "id": 1,
+                                            "text": "This is an attachment"
+                                        }
+                                    ],
+                                    "bot_id": "B19LU7CSY",
+                                    "subtype": "bot_message",
+                                    "text": "Here's a message for you",
+                                    "ts": "1503435956.000247",
+                                    "type": "message",
+                                    "username": "ecto1"
+                                },
+                                "ok": true,
+                                "ts": "1503435956.000247"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.postMessage method",
@@ -10413,6 +11746,12 @@
                     },
                     "default": {
                         "description": "Typical error response if too many attachments are included",
+                        "examples": {
+                            "application/json": {
+                                "error": "too_many_attachments",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.postMessage method",
@@ -10566,6 +11905,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGL",
+                                "message": {
+                                    "attachments": [
+                                        {
+                                            "fallback": "This is an attachment's fallback",
+                                            "id": 1,
+                                            "text": "This is an attachment"
+                                        }
+                                    ],
+                                    "bot_id": "B19LU7CSY",
+                                    "subtype": "bot_message",
+                                    "text": "Here's a message for you in the future",
+                                    "type": "delayed_message",
+                                    "username": "ecto1"
+                                },
+                                "ok": true,
+                                "post_at": "1562180400",
+                                "scheduled_message_id": "Q1298393284"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.scheduleMessage method",
@@ -10655,6 +12016,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the `post_at` is invalid (ex. in the past or too far into the future)",
+                        "examples": {
+                            "application/json": {
+                                "error": "time_in_past",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.scheduleMessage method",
@@ -10784,6 +12151,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                },
+                                "scheduled_messages": [
+                                    {
+                                        "channel_id": "C1H9RESGL",
+                                        "date_created": 1551891734,
+                                        "id": 1298393284,
+                                        "post_at": 1551991428,
+                                        "text": "Here's a message for you in the future"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.scheduledMessages.list method",
@@ -10850,6 +12234,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the channel passed is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.scheduledMessages.list method",
@@ -10974,6 +12364,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical, minimal success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.unfurl method",
@@ -10991,6 +12386,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "cannot_unfurl_url",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.unfurl method",
@@ -11128,6 +12529,18 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE91L",
+                                "message": {
+                                    "text": "Updated text you carefully authored",
+                                    "user": "U34567890"
+                                },
+                                "ok": true,
+                                "text": "Updated text you carefully authored",
+                                "ts": "1401383885.000061"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.update method",
@@ -11179,6 +12592,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_update_message",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.update method",
@@ -11275,6 +12694,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.archive method",
@@ -11292,6 +12716,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.archive method",
@@ -11397,6 +12827,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.close method",
@@ -11420,6 +12855,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.close method",
@@ -11523,6 +12964,48 @@
                 "responses": {
                     "200": {
                         "description": "If successful, the command returns a rather stark [conversation object](/types/conversation)",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1504554479,
+                                    "creator": "U0123456",
+                                    "id": "C0EAQDV4Z",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": false,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_shared": false,
+                                    "last_read": "0000000000.000000",
+                                    "latest": null,
+                                    "name": "endeavor",
+                                    "name_normalized": "endeavor",
+                                    "pending_shared": [],
+                                    "previous_names": [],
+                                    "priority": 0,
+                                    "purpose": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": ""
+                                    },
+                                    "topic": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": ""
+                                    },
+                                    "unlinked": 0,
+                                    "unread_count": 0,
+                                    "unread_count_display": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.create method",
@@ -11544,6 +13027,12 @@
                     },
                     "default": {
                         "description": "Typical error response when name already in use",
+                        "examples": {
+                            "application/json": {
+                                "error": "name_taken",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.create method",
@@ -11681,6 +13170,30 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response containing a channel's messages",
+                        "examples": {
+                            "application/json": {
+                                "has_more": true,
+                                "messages": [
+                                    {
+                                        "text": "I find you punny and would like to smell your nose letter",
+                                        "ts": "1512085950.000216",
+                                        "type": "message",
+                                        "user": "U012AB3CDE"
+                                    },
+                                    {
+                                        "text": "What, you want to smell my shoes better?",
+                                        "ts": "1512104434.000490",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    }
+                                ],
+                                "ok": true,
+                                "pin_count": 0,
+                                "response_metadata": {
+                                    "next_cursor": "bmV4dF90czoxNTEyMDg1ODYxMDAwNTQz"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.history method",
@@ -11742,6 +13255,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.history method",
@@ -11849,6 +13368,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response for a public channel. (Also, a response from a private channel and a multi-party IM is very similar to this example.)",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "parent_conversation": null,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "abstractions",
+                                        "etc",
+                                        "specifics"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.info",
@@ -11870,6 +13434,12 @@
                     },
                     "default": {
                         "description": "Typical error response when a channel cannot be found",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.info method",
@@ -11971,6 +13541,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response when an invitation is extended",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "num_members": 23,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "abstractions",
+                                        "etc",
+                                        "specifics"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.invite method",
@@ -11992,6 +13607,12 @@
                     },
                     "default": {
                         "description": "Typical error response when an invite is attempted on a conversation type that does not support it",
+                        "examples": {
+                            "application/json": {
+                                "error": "method_not_supported_for_channel_type",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.invite method",
@@ -12159,6 +13780,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "U061F7AUR",
+                                    "id": "C061EG9SL",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_shared": false,
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "pending_shared": [],
+                                    "previous_names": [],
+                                    "purpose": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": "For widget discussion"
+                                    },
+                                    "topic": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": "Which widget do you worry about?"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true,
+                                "response_metadata": {
+                                    "warnings": [
+                                        "already_in_channel"
+                                    ]
+                                },
+                                "warning": "already_in_channel"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.join method",
@@ -12197,6 +13861,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the conversation is archived and cannot be joined",
+                        "examples": {
+                            "application/json": {
+                                "error": "is_archived",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.join method",
@@ -12302,6 +13972,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.kick method",
@@ -12319,6 +13994,12 @@
                     },
                     "default": {
                         "description": "Typical error response when you attempt to kick yourself from a channel",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_kick_self",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response conversations.kick method",
@@ -12421,6 +14102,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.leave method",
@@ -12444,6 +14130,12 @@
                     },
                     "default": {
                         "description": "Typical error response when attempting to leave a workspace's \"general\" channel",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_leave_general",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.leave method",
@@ -12565,6 +14257,82 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response with only public channels",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    },
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U061F7AUR",
+                                        "id": "C061EG9T2",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": false,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "random",
+                                        "name_normalized": "random",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Non-work banter and water cooler conversation"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.list method",
@@ -12602,6 +14370,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.list method",
@@ -12701,6 +14475,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.mark method",
@@ -12718,6 +14497,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.mark method",
@@ -12827,6 +14612,19 @@
                 "responses": {
                     "200": {
                         "description": "Typical paginated success response",
+                        "examples": {
+                            "application/json": {
+                                "members": [
+                                    "U023BECGF",
+                                    "U061F7AUR",
+                                    "W012A3CDE"
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "e3VzZXJfaWQ6IFcxMjM0NTY3fQ=="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.members method",
@@ -12866,6 +14664,12 @@
                     },
                     "default": {
                         "description": "Typical error response when an invalid cursor is provided",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response conversations.members method",
@@ -12969,6 +14773,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "id": "D069C7QFK"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.open method when opening channels, ims, mpims",
@@ -13036,6 +14848,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.open method",
@@ -13138,6 +14956,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "num_members": 23,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "abstractions",
+                                        "etc",
+                                        "specifics"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.rename method",
@@ -13159,6 +15022,12 @@
                     },
                     "default": {
                         "description": "Typical error response when the calling user is not a member of the conversation",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_in_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.rename method",
@@ -13298,6 +15167,52 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "has_more": true,
+                                "messages": [
+                                    {
+                                        "last_read": "1484678597.521003",
+                                        "reply_count": 3,
+                                        "subscribed": true,
+                                        "text": "island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1482960137.003543",
+                                        "type": "message",
+                                        "unread_count": 0,
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "one island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483037603.017503",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "two island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483051909.018632",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "three for the land",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483125339.020269",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "bmV4dF90czoxNDg0Njc4MjkwNTE3MDkx"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.replies method",
@@ -13452,6 +15367,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "thread_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.replies method",
@@ -13554,6 +15475,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.setPurpose method",
@@ -13575,6 +15501,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.setPurpose method",
@@ -13681,6 +15613,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.setTopic method",
@@ -13702,6 +15639,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.setTopic method",
@@ -13802,6 +15745,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.unarchive method",
@@ -13819,6 +15767,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.unarchive method",
@@ -13929,6 +15883,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response is quite minimal.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dialog.open method",
@@ -13946,6 +15905,12 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "missing_trigger",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dialog.open method",
@@ -14037,6 +16002,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.endDnd method",
@@ -14054,6 +16024,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.endDnd method",
@@ -14138,6 +16114,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.endSnooze method",
@@ -14171,6 +16152,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.endSnooze method",
@@ -14261,6 +16248,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.info method",
@@ -14299,6 +16291,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.info method",
@@ -14388,6 +16386,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.setSnooze method",
@@ -14417,6 +16420,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.setSnooze method",
@@ -14508,6 +16517,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": {
+                                    "U023BECGF": {
+                                        "dnd_enabled": true,
+                                        "next_dnd_end_ts": 1450423800,
+                                        "next_dnd_start_ts": 1450387800
+                                    },
+                                    "W058CJVAA": {
+                                        "dnd_enabled": false,
+                                        "next_dnd_end_ts": 1,
+                                        "next_dnd_start_ts": 1
+                                    }
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -14525,8 +16551,14 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
                             "properties": {
                                 "ok": {
@@ -14578,6 +16610,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -14595,6 +16632,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -14661,6 +16704,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response is very simple",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.comments.delete method",
@@ -14678,6 +16726,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "file_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.comments.delete method",
@@ -14765,6 +16819,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.delete method",
@@ -14782,6 +16841,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.delete method",
@@ -14891,6 +16956,77 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "comments": [],
+                                "file": {
+                                    "channels": [
+                                        "C0T8SE4AU"
+                                    ],
+                                    "comments_count": 0,
+                                    "created": 1531763342,
+                                    "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+                                    "display_as_bot": false,
+                                    "editable": false,
+                                    "external_type": "",
+                                    "filetype": "gif",
+                                    "groups": [],
+                                    "has_rich_preview": false,
+                                    "id": "F0S43PZDF",
+                                    "image_exif_rotation": 1,
+                                    "ims": [],
+                                    "is_external": false,
+                                    "is_public": true,
+                                    "is_starred": false,
+                                    "mimetype": "image/gif",
+                                    "mode": "hosted",
+                                    "name": "tedair.gif",
+                                    "original_h": 226,
+                                    "original_w": 176,
+                                    "permalink": "https://.../tedair.gif",
+                                    "permalink_public": "https://.../...",
+                                    "pjpeg": "https://.../tedair_pjpeg.jpg",
+                                    "pretty_type": "GIF",
+                                    "public_url_shared": false,
+                                    "shares": {
+                                        "public": {
+                                            "C0T8SE4AU": [
+                                                {
+                                                    "channel_name": "file-under",
+                                                    "latest_reply": "1531763348.000001",
+                                                    "reply_count": 1,
+                                                    "reply_users": [
+                                                        "U061F7AUR"
+                                                    ],
+                                                    "reply_users_count": 1,
+                                                    "team_id": "T061EG9R6",
+                                                    "thread_ts": "1531763273.000015",
+                                                    "ts": "1531763348.000001"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "size": 137531,
+                                    "thumb_160": "https://.../tedair_=_160.png",
+                                    "thumb_360": "https://.../tedair_360.png",
+                                    "thumb_360_gif": "https://.../tedair_360.gif",
+                                    "thumb_360_h": 226,
+                                    "thumb_360_w": 176,
+                                    "thumb_64": "https://.../tedair_64.png",
+                                    "thumb_80": "https://.../tedair_80.png",
+                                    "timestamp": 1531763342,
+                                    "title": "tedair.gif",
+                                    "url_private": "https://.../tedair.gif",
+                                    "url_private_download": "https://.../tedair.gif",
+                                    "user": "U061F7AUR",
+                                    "username": ""
+                                },
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.info method",
@@ -14928,6 +17064,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.info method",
@@ -15055,6 +17197,103 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "files": [
+                                    {
+                                        "channels": [
+                                            "C0T8SE4AU"
+                                        ],
+                                        "comments_count": 0,
+                                        "created": 1531763254,
+                                        "deanimate_gif": "https://.../billair_deanimate_gif.png",
+                                        "display_as_bot": false,
+                                        "editable": false,
+                                        "external_type": "",
+                                        "filetype": "gif",
+                                        "groups": [],
+                                        "id": "F0S43P1CZ",
+                                        "image_exif_rotation": 1,
+                                        "ims": [],
+                                        "is_external": false,
+                                        "is_public": true,
+                                        "mimetype": "image/gif",
+                                        "mode": "hosted",
+                                        "name": "billair.gif",
+                                        "original_h": 226,
+                                        "original_w": 176,
+                                        "permalink": "https://.../billair.gif",
+                                        "permalink_public": "https://.../...",
+                                        "pjpeg": "https://.../billair_pjpeg.jpg",
+                                        "pretty_type": "GIF",
+                                        "public_url_shared": false,
+                                        "size": 144538,
+                                        "thumb_160": "https://.../billair_=_160.png",
+                                        "thumb_360": "https://.../billair_360.png",
+                                        "thumb_360_gif": "https://.../billair_360.gif",
+                                        "thumb_360_h": 226,
+                                        "thumb_360_w": 176,
+                                        "thumb_64": "https://.../billair_64.png",
+                                        "thumb_80": "https://.../billair_80.png",
+                                        "timestamp": 1531763254,
+                                        "title": "billair.gif",
+                                        "url_private": "https://.../billair.gif",
+                                        "url_private_download": "https://.../billair.gif",
+                                        "user": "U061F7AUR",
+                                        "username": ""
+                                    },
+                                    {
+                                        "channels": [
+                                            "C0T8SE4AU"
+                                        ],
+                                        "comments_count": 0,
+                                        "created": 1531763342,
+                                        "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+                                        "display_as_bot": false,
+                                        "editable": false,
+                                        "external_type": "",
+                                        "filetype": "gif",
+                                        "groups": [],
+                                        "id": "F0S43PZDF",
+                                        "image_exif_rotation": 1,
+                                        "ims": [],
+                                        "is_external": false,
+                                        "is_public": true,
+                                        "mimetype": "image/gif",
+                                        "mode": "hosted",
+                                        "name": "tedair.gif",
+                                        "original_h": 226,
+                                        "original_w": 176,
+                                        "permalink": "https://.../tedair.gif",
+                                        "permalink_public": "https://.../...",
+                                        "pjpeg": "https://.../tedair_pjpeg.jpg",
+                                        "pretty_type": "GIF",
+                                        "public_url_shared": false,
+                                        "size": 137531,
+                                        "thumb_160": "https://.../tedair_=_160.png",
+                                        "thumb_360": "https://.../tedair_360.png",
+                                        "thumb_360_gif": "https://.../tedair_360.gif",
+                                        "thumb_360_h": 226,
+                                        "thumb_360_w": 176,
+                                        "thumb_64": "https://.../tedair_64.png",
+                                        "thumb_80": "https://.../tedair_80.png",
+                                        "timestamp": 1531763342,
+                                        "title": "tedair.gif",
+                                        "url_private": "https://.../tedair.gif",
+                                        "url_private_download": "https://.../tedair.gif",
+                                        "user": "U061F7AUR",
+                                        "username": ""
+                                    }
+                                ],
+                                "ok": true,
+                                "paging": {
+                                    "count": 100,
+                                    "page": 1,
+                                    "pages": 1,
+                                    "total": 2
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.list method",
@@ -15085,6 +17324,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.list method",
@@ -15202,6 +17447,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15219,6 +17469,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15285,6 +17541,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15302,6 +17563,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15386,6 +17653,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15403,6 +17675,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15469,6 +17747,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15486,6 +17769,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15558,6 +17847,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15575,6 +17869,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15671,6 +17971,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15688,6 +17993,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15749,6 +18060,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.revokePublicURL method",
@@ -15770,6 +18086,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.revokePublicURL method",
@@ -15861,6 +18183,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.sharedPublicURL method",
@@ -15882,6 +18209,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.sharedPublicURL method",
@@ -16015,6 +18348,67 @@
                 "responses": {
                     "200": {
                         "description": "Success response after uploading a file to a channel with an initial message",
+                        "examples": {
+                            "application/json": {
+                                "file": {
+                                    "channels": [],
+                                    "comments_count": 0,
+                                    "created": 1532293501,
+                                    "display_as_bot": false,
+                                    "editable": false,
+                                    "external_type": "",
+                                    "filetype": "gif",
+                                    "groups": [],
+                                    "has_rich_preview": false,
+                                    "id": "F0TD00400",
+                                    "image_exif_rotation": 1,
+                                    "ims": [
+                                        "D0L4B9P0Q"
+                                    ],
+                                    "is_external": false,
+                                    "is_public": false,
+                                    "is_starred": false,
+                                    "mimetype": "image/jpeg",
+                                    "mode": "hosted",
+                                    "name": "dramacat.gif",
+                                    "original_h": 366,
+                                    "original_w": 526,
+                                    "permalink": "https://.../dramacat.gif",
+                                    "permalink_public": "https://.../More-Path-Components",
+                                    "pretty_type": "JPEG",
+                                    "public_url_shared": false,
+                                    "shares": {
+                                        "private": {
+                                            "D0L4B9P0Q": [
+                                                {
+                                                    "reply_count": 0,
+                                                    "reply_users": [],
+                                                    "reply_users_count": 0,
+                                                    "ts": "1532293503.000001"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "size": 43518,
+                                    "thumb_160": "https://.../dramacat_160.gif",
+                                    "thumb_360": "https://.../dramacat_360.gif",
+                                    "thumb_360_h": 250,
+                                    "thumb_360_w": 360,
+                                    "thumb_480": "https://.../dramacat_480.gif",
+                                    "thumb_480_h": 334,
+                                    "thumb_480_w": 480,
+                                    "thumb_64": "https://.../dramacat_64.gif",
+                                    "thumb_80": "https://.../dramacat_80.gif",
+                                    "timestamp": 1532293501,
+                                    "title": "dramacat",
+                                    "url_private": "https://.../dramacat.gif",
+                                    "url_private_download": "https://.../dramacat.gif",
+                                    "user": "U0L4B9NSU",
+                                    "username": ""
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.upload method",
@@ -16036,6 +18430,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.upload method",
@@ -16047,7 +18447,6 @@
                                 "error": {
                                     "enum": [
                                         "account_inactive",
-                                        "file_upload_size_restricted",
                                         "file_uploads_disabled",
                                         "file_uploads_except_images_disabled",
                                         "invalid_arg_name",
@@ -16139,6 +18538,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response when mappings exist for the specified user IDs",
+                        "examples": {
+                            "application/json": {
+                                "enterprise_id": "E1KQTNXE1",
+                                "invalid_user_ids": [
+                                    "U21ABZZXX"
+                                ],
+                                "ok": true,
+                                "team_id": "T1KR7PE1W",
+                                "user_id_map": {
+                                    "U06UBSUN5": "W06M56XJM",
+                                    "U06UBSVB3": "W06PUUDLY",
+                                    "U06UBSVDX": "W06PUUDMW",
+                                    "U06UEB62U": "W06PTT6GH",
+                                    "W06UAZ65Q": "W06UAZ65Q"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from migration.exchange method",
@@ -16177,6 +18593,12 @@
                     },
                     "default": {
                         "description": "Typical error response when there are no mappings to provide",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_enterprise_team",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from migration.exchange method",
@@ -16284,6 +18706,15 @@
                 "responses": {
                     "200": {
                         "description": "Successful user token negotiation for a single scope",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
+                                "enterprise_id": null,
+                                "scope": "groups:write",
+                                "team_id": "TXXXXXXXXX",
+                                "team_name": "Wyld Stallyns LLC"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16301,6 +18732,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16378,6 +18815,30 @@
                 "responses": {
                     "200": {
                         "description": "Success example using a workspace app produces a very different kind of response",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxa-access-token-string",
+                                "app_id": "A012345678",
+                                "app_user_id": "U0AB12ABC",
+                                "authorizing_user_id": "U0HTT3Q0G",
+                                "installer_user_id": "U061F7AUR",
+                                "ok": true,
+                                "permissions": [
+                                    {
+                                        "resource_id": 0,
+                                        "resource_type": "channel",
+                                        "scopes": [
+                                            "channels:read",
+                                            "chat:write:user"
+                                        ]
+                                    }
+                                ],
+                                "single_channel_id": "C061EG9T2",
+                                "team_id": "T061EG9Z9",
+                                "team_name": "Subarachnoid Workspace",
+                                "token_type": "app"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16395,6 +18856,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16467,6 +18934,30 @@
                 "responses": {
                     "200": {
                         "description": "Successful token request with scopes for both a bot user and a user token",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+                                "app_id": "A0KRD7HC3",
+                                "authed_user": {
+                                    "access_token": "xoxp-1234",
+                                    "id": "U1234",
+                                    "scope": "chat:write",
+                                    "token_type": "user"
+                                },
+                                "bot_user_id": "U0KRQLJ9H",
+                                "enterprise": {
+                                    "id": "E12345678",
+                                    "name": "slack-sports"
+                                },
+                                "ok": true,
+                                "scope": "commands,incoming-webhook",
+                                "team": {
+                                    "id": "T9TK3CUKW",
+                                    "name": "Slack Softball Team"
+                                },
+                                "token_type": "bot"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16484,6 +18975,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16551,6 +19048,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from pins.add method",
@@ -16568,6 +19070,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.add method",
@@ -16660,6 +19168,45 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "items": [
+                                    {
+                                        "channel": "C2U86NC6H",
+                                        "created": 1508881078,
+                                        "created_by": "U2U85N1RZ",
+                                        "message": {
+                                            "permalink": "https://hitchhikers.slack.com/archives/C2U86NC6H/p1508197641000151",
+                                            "pinned_to": [
+                                                "C2U86NC6H"
+                                            ],
+                                            "text": "What is the meaning of life?",
+                                            "ts": "1508197641.000151",
+                                            "type": "message",
+                                            "user": "U2U85N1RZ"
+                                        },
+                                        "type": "message"
+                                    },
+                                    {
+                                        "channel": "C2U86NC6H",
+                                        "created": 1508880991,
+                                        "created_by": "U2U85N1RZ",
+                                        "message": {
+                                            "permalink": "https://hitchhikers.slack.com/archives/C2U86NC6H/p1508284197000015",
+                                            "pinned_to": [
+                                                "C2U86NC6H"
+                                            ],
+                                            "text": "The meaning of life, the universe, and everything is 42.",
+                                            "ts": "1503289197.000015",
+                                            "type": "message",
+                                            "user": "U2U85N1RZ"
+                                        },
+                                        "type": "message"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from pins.list method",
                             "items": [
@@ -16751,6 +19298,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.list method",
@@ -16844,6 +19397,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from pins.remove method",
@@ -16861,6 +19419,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "no_pin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.remove method",
@@ -16968,6 +19532,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.add method",
@@ -16985,6 +19554,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "already_reacted",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.add method",
@@ -17100,6 +19675,35 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "file": {
+                                    "channels": [
+                                        "C2U7V2YA2"
+                                    ],
+                                    "comments_count": 1,
+                                    "created": 1507850315,
+                                    "groups": [],
+                                    "id": "F7H0D7ZA4",
+                                    "ims": [],
+                                    "name": "computer.gif",
+                                    "reactions": [
+                                        {
+                                            "count": 1,
+                                            "name": "stuck_out_tongue_winking_eye",
+                                            "users": [
+                                                "U2U85N1RV"
+                                            ]
+                                        }
+                                    ],
+                                    "timestamp": 1507850315,
+                                    "title": "computer.gif",
+                                    "user": "U2U85N1RV"
+                                },
+                                "ok": true,
+                                "type": "file"
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from reactions.get method",
                             "oneOf": [
@@ -17178,11 +19782,18 @@
                                     ]
                                 }
                             ],
-                            "title": "reactions.get success schema"
+                            "title": "reactions.get success schema",
+                            "type": "object"
                         }
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.get method",
@@ -17299,6 +19910,99 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "items": [
+                                    {
+                                        "channel": "C3UKJTQAC",
+                                        "message": {
+                                            "bot_id": "B4VLRLMKJ",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "robot_face",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "subtype": "bot_message",
+                                            "text": "Hello from Python! :tada:",
+                                            "ts": "1507849573.000090",
+                                            "username": "Shipit Notifications"
+                                        },
+                                        "type": "message"
+                                    },
+                                    {
+                                        "comment": {
+                                            "comment": "This is a file comment",
+                                            "created": 1508286096,
+                                            "id": "Fc7LP08P1U",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "white_check_mark",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "timestamp": 1508286096,
+                                            "type": "file_comment",
+                                            "user": "U2U85N1RV"
+                                        },
+                                        "file": {
+                                            "channels": [
+                                                "C2U7V2YA2"
+                                            ],
+                                            "comments_count": 1,
+                                            "created": 1507850315,
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "stuck_out_tongue_winking_eye",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "title": "computer.gif",
+                                            "user": "U2U85N1RV",
+                                            "username": ""
+                                        }
+                                    },
+                                    {
+                                        "file": {
+                                            "channels": [
+                                                "C2U7V2YA2"
+                                            ],
+                                            "comments_count": 1,
+                                            "created": 1507850315,
+                                            "id": "F7H0D7ZA4",
+                                            "name": "computer.gif",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "stuck_out_tongue_winking_eye",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "size": 1639034,
+                                            "title": "computer.gif",
+                                            "user": "U2U85N1RV",
+                                            "username": ""
+                                        },
+                                        "type": "file"
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.list method",
@@ -17395,6 +20099,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.list method",
@@ -17507,6 +20217,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.remove method",
@@ -17524,6 +20239,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "no_reaction",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.remove method",
@@ -17631,6 +20352,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.add method",
@@ -17652,6 +20378,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.add method",
@@ -17747,6 +20479,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.complete method",
@@ -17764,6 +20501,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.complete method",
@@ -17856,6 +20599,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.delete method",
@@ -17873,6 +20621,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.delete method",
@@ -17962,6 +20716,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.info method",
@@ -17983,6 +20742,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.info method",
@@ -18066,6 +20831,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.list method",
@@ -18090,6 +20860,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.list method",
@@ -18184,6 +20960,21 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "self": {
+                                    "id": "U4X318ZMZ",
+                                    "name": "robotoverlord"
+                                },
+                                "team": {
+                                    "domain": "slackdemo",
+                                    "id": "T2U81E2FP",
+                                    "name": "SlackDemo"
+                                },
+                                "url": "wss://..."
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from rtm.connect method",
@@ -18244,6 +21035,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from rtm.connect method",
@@ -18360,6 +21157,73 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "messages": {
+                                    "matches": [
+                                        {
+                                            "channel": {
+                                                "id": "C12345678",
+                                                "is_ext_shared": false,
+                                                "is_mpim": false,
+                                                "is_org_shared": false,
+                                                "is_pending_ext_shared": false,
+                                                "is_private": false,
+                                                "is_shared": false,
+                                                "name": "general",
+                                                "pending_shared": []
+                                            },
+                                            "iid": "cb64bdaa-c1e8-4631-8a91-0f78080113e9",
+                                            "permalink": "https://hitchhikers.slack.com/archives/C12345678/p1508284197000015",
+                                            "team": "T12345678",
+                                            "text": "The meaning of life the universe and everything is 42.",
+                                            "ts": "1508284197.000015",
+                                            "type": "message",
+                                            "user": "U2U85N1RV",
+                                            "username": "roach"
+                                        },
+                                        {
+                                            "channel": {
+                                                "id": "C12345678",
+                                                "is_ext_shared": false,
+                                                "is_mpim": false,
+                                                "is_org_shared": false,
+                                                "is_pending_ext_shared": false,
+                                                "is_private": false,
+                                                "is_shared": false,
+                                                "name": "random",
+                                                "pending_shared": []
+                                            },
+                                            "iid": "9a00d3c9-bd2d-45b0-988b-6cff99ae2a90",
+                                            "permalink": "https://hitchhikers.slack.com/archives/C12345678/p1508795665000236",
+                                            "team": "T12345678",
+                                            "text": "The meaning of life the universe and everything is 101010",
+                                            "ts": "1508795665.000236",
+                                            "type": "message",
+                                            "user": "",
+                                            "username": "robot overlord"
+                                        }
+                                    ],
+                                    "pagination": {
+                                        "first": 1,
+                                        "last": 2,
+                                        "page": 1,
+                                        "page_count": 1,
+                                        "per_page": 20,
+                                        "total_count": 2
+                                    },
+                                    "paging": {
+                                        "count": 20,
+                                        "page": 1,
+                                        "pages": 1,
+                                        "total": 2
+                                    },
+                                    "total": 2
+                                },
+                                "ok": true,
+                                "query": "The meaning of life the universe and everything"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -18377,6 +21241,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "No query passed",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -18455,6 +21325,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.add method",
@@ -18472,6 +21347,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.add method",
@@ -18582,6 +21463,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.list method",
@@ -18756,6 +21642,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.list method",
@@ -18863,6 +21755,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.remove method",
@@ -18880,6 +21777,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.remove method",
@@ -18984,6 +21887,43 @@
                 "responses": {
                     "200": {
                         "description": "This response demonstrates pagination and two access log entries.",
+                        "examples": {
+                            "application/json": {
+                                "logins": [
+                                    {
+                                        "count": 1,
+                                        "country": "US",
+                                        "date_first": 1422922864,
+                                        "date_last": 1422922864,
+                                        "ip": "127.0.0.1",
+                                        "isp": "BigCo ISP",
+                                        "region": "CA",
+                                        "user_agent": "SlackWeb Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.35 Safari/537.36",
+                                        "user_id": "U45678",
+                                        "username": "alice"
+                                    },
+                                    {
+                                        "count": 1,
+                                        "country": "US",
+                                        "date_first": 1422922493,
+                                        "date_last": 1422922493,
+                                        "ip": "127.0.0.1",
+                                        "isp": "BigCo ISP",
+                                        "region": "CA",
+                                        "user_agent": "SlackWeb Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4",
+                                        "user_id": "U12345",
+                                        "username": "white_rabbit"
+                                    }
+                                ],
+                                "ok": true,
+                                "paging": {
+                                    "count": 100,
+                                    "page": 1,
+                                    "pages": 1,
+                                    "total": 2
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.accessLogs method",
@@ -19071,6 +22011,12 @@
                     },
                     "default": {
                         "description": "A workspace must be on a paid plan to use this method, otherwise the `paid_only` error is thrown:",
+                        "examples": {
+                            "application/json": {
+                                "error": "paid_only",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.accessLogs method",
@@ -19161,6 +22107,22 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "billable_info": {
+                                    "U02UCPE1R": {
+                                        "billing_active": true
+                                    },
+                                    "U02UEBSD2": {
+                                        "billing_active": true
+                                    },
+                                    "U0632EWRW": {
+                                        "billing_active": false
+                                    }
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -19178,6 +22140,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -19237,6 +22205,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "domain": "example",
+                                    "email_domain": "example.com",
+                                    "enterprise_id": "E1234A12AB",
+                                    "enterprise_name": "Umbrella Corporation",
+                                    "icon": {
+                                        "image_102": "https://...",
+                                        "image_132": "https://...",
+                                        "image_34": "https://...",
+                                        "image_44": "https://...",
+                                        "image_68": "https://...",
+                                        "image_88": "https://...",
+                                        "image_default": true
+                                    },
+                                    "id": "T12345",
+                                    "name": "My Team"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.info method",
@@ -19258,6 +22248,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.info method",
@@ -19372,6 +22368,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.integrationLogs method",
@@ -19447,6 +22448,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.integrationLogs method",
@@ -19535,6 +22542,77 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "fields": [
+                                        {
+                                            "hint": "Enter the extension to reach your desk",
+                                            "id": "Xf06054AAA",
+                                            "is_hidden": 1,
+                                            "label": "Phone extension",
+                                            "options": null,
+                                            "ordering": 0,
+                                            "possible_values": null,
+                                            "type": "text"
+                                        },
+                                        {
+                                            "hint": "When you were born",
+                                            "id": "Xf06054BBB",
+                                            "label": "Date of birth",
+                                            "options": null,
+                                            "ordering": 1,
+                                            "possible_values": null,
+                                            "type": "date"
+                                        },
+                                        {
+                                            "hint": "Enter a link to your Facebook profile",
+                                            "id": "Xf06054CCC",
+                                            "label": "Facebook",
+                                            "options": null,
+                                            "ordering": 2,
+                                            "possible_values": null,
+                                            "type": "link"
+                                        },
+                                        {
+                                            "hint": "Hogwarts, obviously",
+                                            "id": "Xf06054DDD",
+                                            "label": "House",
+                                            "options": null,
+                                            "ordering": 3,
+                                            "possible_values": [
+                                                "Gryffindor",
+                                                "Hufflepuff",
+                                                "Ravenclaw",
+                                                "Slytherin"
+                                            ],
+                                            "type": "options_list"
+                                        },
+                                        {
+                                            "hint": "Office location (LDAP)",
+                                            "id": "Xf06054EEE",
+                                            "label": "Location",
+                                            "options": {
+                                                "is_protected": 1
+                                            },
+                                            "ordering": 4,
+                                            "possible_values": null,
+                                            "type": "text"
+                                        },
+                                        {
+                                            "hint": "The boss",
+                                            "id": "Xf06054FFF",
+                                            "label": "Manager",
+                                            "options": null,
+                                            "ordering": 5,
+                                            "possible_values": null,
+                                            "type": "user"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.profile.get method",
@@ -19569,6 +22647,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.profile.get method",
@@ -19681,6 +22765,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.create method",
@@ -19702,6 +22791,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.create method",
@@ -19800,6 +22895,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.disable method",
@@ -19821,6 +22921,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.disable method",
@@ -19919,6 +23025,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.enable method",
@@ -19940,6 +23051,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.enable method",
@@ -20043,6 +23160,76 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroups": [
+                                    {
+                                        "auto_type": "admin",
+                                        "created_by": "USLACKBOT",
+                                        "date_create": 1446598059,
+                                        "date_delete": 0,
+                                        "date_update": 1446670362,
+                                        "deleted_by": null,
+                                        "description": "A group of all Administrators on your team.",
+                                        "handle": "admins",
+                                        "id": "S0614TZR7",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Team Admins",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "U060RNRCZ",
+                                        "user_count": "2"
+                                    },
+                                    {
+                                        "auto_type": "owner",
+                                        "created_by": "USLACKBOT",
+                                        "date_create": 1446678371,
+                                        "date_delete": 0,
+                                        "date_update": 1446678371,
+                                        "deleted_by": null,
+                                        "description": "A group of all Owners on your team.",
+                                        "handle": "owners",
+                                        "id": "S06158AV7",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Team Owners",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "USLACKBOT",
+                                        "user_count": "1"
+                                    },
+                                    {
+                                        "auto_type": null,
+                                        "created_by": "U060RNRCZ",
+                                        "date_create": 1446746793,
+                                        "date_delete": 1446748865,
+                                        "date_update": 1446747767,
+                                        "deleted_by": null,
+                                        "description": "Marketing gurus, PR experts and product advocates.",
+                                        "handle": "marketing-team",
+                                        "id": "S0615G0KT",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Marketing Team",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "U060RNRCZ",
+                                        "user_count": "0"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.list method",
@@ -20067,6 +23254,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.list method",
@@ -20190,6 +23383,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroup": {
+                                    "auto_type": null,
+                                    "created_by": "U060R4BJ4",
+                                    "date_create": 1447096577,
+                                    "date_delete": 0,
+                                    "date_update": 1447102109,
+                                    "deleted_by": null,
+                                    "description": "Marketing gurus, PR experts and product advocates.",
+                                    "handle": "marketing-team",
+                                    "id": "S0616NG6M",
+                                    "is_external": false,
+                                    "is_usergroup": true,
+                                    "name": "Marketing Team",
+                                    "prefs": {
+                                        "channels": [],
+                                        "groups": []
+                                    },
+                                    "team_id": "T060R4BHN",
+                                    "updated_by": "U060R4BJ4",
+                                    "user_count": 1,
+                                    "users": [
+                                        "U060R4BJ4",
+                                        "U060RNRCZ"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.update method",
@@ -20211,6 +23434,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.update method",
@@ -20310,6 +23539,15 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": [
+                                    "U060R4BJ4",
+                                    "W123A4BC5"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.users.list method",
@@ -20334,6 +23572,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.users.list method",
@@ -20441,6 +23685,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroup": {
+                                    "auto_type": null,
+                                    "created_by": "U060R4BJ4",
+                                    "date_create": 1447096577,
+                                    "date_delete": 0,
+                                    "date_update": 1447102109,
+                                    "deleted_by": null,
+                                    "description": "Marketing gurus, PR experts and product advocates.",
+                                    "handle": "marketing-team",
+                                    "id": "S0616NG6M",
+                                    "is_external": false,
+                                    "is_usergroup": true,
+                                    "name": "Marketing Team",
+                                    "prefs": {
+                                        "channels": [],
+                                        "groups": []
+                                    },
+                                    "team_id": "T060R4BHN",
+                                    "updated_by": "U060R4BJ4",
+                                    "user_count": 1,
+                                    "users": [
+                                        "U060R4BJ4",
+                                        "U060RNRCZ"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.users.update method",
@@ -20462,6 +23736,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.users.update method",
@@ -20579,6 +23859,78 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response with only public channels. Note how `num_members` and `is_member` are not returned like typical `conversations` objects.",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    },
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U061F7AUR",
+                                        "id": "C061EG9T2",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": false,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "random",
+                                        "name_normalized": "random",
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Non-work banter and water cooler conversation"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.conversations method. Returned conversation objects do not include `num_members` or `is_member`",
@@ -20616,6 +23968,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.conversations method",
@@ -20704,6 +24062,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.deletePhoto method",
@@ -20721,6 +24084,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.deletePhoto method",
@@ -20809,6 +24178,12 @@
                 "responses": {
                     "200": {
                         "description": "When requesting information for a different user, this method just returns the current presence (either `active` or `away`).",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "presence": "active"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Generated from users.getPresence with shasum e7251aec575d8863f9e0eb38663ae9dc26655f65",
@@ -20845,6 +24220,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -20904,6 +24285,18 @@
                 "responses": {
                     "200": {
                         "description": "You will receive at a minimum the following information:",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "id": "T0G9PQBBK"
+                                },
+                                "user": {
+                                    "id": "U0G9QF9C6",
+                                    "name": "Sonny Whether"
+                                }
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from users.identity method",
                             "items": [
@@ -21167,6 +24560,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "account_inactive",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.identity method",
@@ -21261,6 +24660,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "user": {
+                                    "color": "9f69e7",
+                                    "deleted": false,
+                                    "has_2fa": false,
+                                    "id": "W012A3CDE",
+                                    "is_admin": true,
+                                    "is_app_user": false,
+                                    "is_bot": false,
+                                    "is_owner": false,
+                                    "is_primary_owner": false,
+                                    "is_restricted": false,
+                                    "is_ultra_restricted": false,
+                                    "name": "spengler",
+                                    "profile": {
+                                        "avatar_hash": "ge3b51ca72de",
+                                        "display_name": "spengler",
+                                        "display_name_normalized": "spengler",
+                                        "email": "spengler@ghostbusters.example.com",
+                                        "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "real_name": "Egon Spengler",
+                                        "real_name_normalized": "Egon Spengler",
+                                        "status_emoji": ":books:",
+                                        "status_text": "Print is dead",
+                                        "team": "T012AB3C4"
+                                    },
+                                    "real_name": "Egon Spengler",
+                                    "team_id": "T012AB3C4",
+                                    "tz": "America/Los_Angeles",
+                                    "tz_label": "Pacific Daylight Time",
+                                    "tz_offset": -25200,
+                                    "updated": 1502138686
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.info method",
@@ -21282,6 +24724,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.info method",
@@ -21378,6 +24826,94 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "cache_ts": 1498777272,
+                                "members": [
+                                    {
+                                        "color": "9f69e7",
+                                        "deleted": false,
+                                        "has_2fa": false,
+                                        "id": "W012A3CDE",
+                                        "is_admin": true,
+                                        "is_app_user": false,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false,
+                                        "name": "spengler",
+                                        "profile": {
+                                            "avatar_hash": "ge3b51ca72de",
+                                            "display_name": "spengler",
+                                            "display_name_normalized": "spengler",
+                                            "email": "spengler@ghostbusters.example.com",
+                                            "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "real_name": "Egon Spengler",
+                                            "real_name_normalized": "Egon Spengler",
+                                            "status_emoji": ":books:",
+                                            "status_text": "Print is dead",
+                                            "team": "T012AB3C4"
+                                        },
+                                        "real_name": "spengler",
+                                        "team_id": "T012AB3C4",
+                                        "tz": "America/Los_Angeles",
+                                        "tz_label": "Pacific Daylight Time",
+                                        "tz_offset": -25200,
+                                        "updated": 1502138686
+                                    },
+                                    {
+                                        "color": "9f69e7",
+                                        "deleted": false,
+                                        "has_2fa": false,
+                                        "id": "W07QCRPA4",
+                                        "is_admin": true,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false,
+                                        "name": "glinda",
+                                        "profile": {
+                                            "avatar_hash": "8fbdd10b41c6",
+                                            "display_name": "Glinda the Fairly Good",
+                                            "display_name_normalized": "Glinda the Fairly Good",
+                                            "email": "glenda@south.oz.coven",
+                                            "first_name": "Glinda",
+                                            "image_1024": "https://a.slack-edge.com...png",
+                                            "image_192": "https://a.slack-edge.com...png",
+                                            "image_24": "https://a.slack-edge.com...png",
+                                            "image_32": "https://a.slack-edge.com...png",
+                                            "image_48": "https://a.slack-edge.com...png",
+                                            "image_512": "https://a.slack-edge.com...png",
+                                            "image_72": "https://a.slack-edge.com...png",
+                                            "image_original": "https://a.slack-edge.com...png",
+                                            "last_name": "Southgood",
+                                            "phone": "",
+                                            "real_name": "Glinda Southgood",
+                                            "real_name_normalized": "Glinda Southgood",
+                                            "skype": "",
+                                            "title": "Glinda the Good"
+                                        },
+                                        "real_name": "Glinda Southgood",
+                                        "team_id": "T0G9PQBBK",
+                                        "tz": "America/Los_Angeles",
+                                        "tz_label": "Pacific Daylight Time",
+                                        "tz_offset": -25200,
+                                        "updated": 1480527098
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dXNlcjpVMEc5V0ZYTlo="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.list method",
@@ -21411,6 +24947,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.list method",
@@ -21498,6 +25040,48 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "user": {
+                                    "color": "9f69e7",
+                                    "deleted": false,
+                                    "has_2fa": false,
+                                    "id": "W012A3CDE",
+                                    "is_admin": true,
+                                    "is_app_user": false,
+                                    "is_bot": false,
+                                    "is_owner": false,
+                                    "is_primary_owner": false,
+                                    "is_restricted": false,
+                                    "is_ultra_restricted": false,
+                                    "name": "spengler",
+                                    "profile": {
+                                        "avatar_hash": "ge3b51ca72de",
+                                        "display_name": "spengler",
+                                        "display_name_normalized": "spengler",
+                                        "email": "spengler@ghostbusters.example.com",
+                                        "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "real_name": "Egon Spengler",
+                                        "real_name_normalized": "Egon Spengler",
+                                        "status_emoji": ":books:",
+                                        "status_text": "Print is dead",
+                                        "team": "T012AB3C4"
+                                    },
+                                    "real_name": "Egon Spengler",
+                                    "team_id": "T012AB3C4",
+                                    "tz": "America/Los_Angeles",
+                                    "tz_label": "Pacific Daylight Time",
+                                    "tz_offset": -25200,
+                                    "updated": 1502138686
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.lookupByEmail method",
@@ -21519,6 +25103,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "users_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.lookupByEmail method",
@@ -21612,6 +25202,30 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "avatar_hash": "ge3b51ca72de",
+                                    "display_name": "spengler",
+                                    "display_name_normalized": "spengler",
+                                    "email": "spengler@ghostbusters.example.com",
+                                    "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "real_name": "Egon Spengler",
+                                    "real_name_normalized": "Egon Spengler",
+                                    "status_emoji": ":books:",
+                                    "status_expiration": 0,
+                                    "status_text": "Print is dead",
+                                    "team": "T012AB3C4"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.profile.get method",
@@ -21633,6 +25247,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.profile.get method",
@@ -21742,6 +25362,29 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "avatar_hash": "ge3b51ca72de",
+                                    "display_name": "spengler",
+                                    "display_name_normalized": "spengler",
+                                    "email": "spengler@ghostbusters.example.com",
+                                    "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "real_name": "Egon Spengler",
+                                    "real_name_normalized": "Egon Spengler",
+                                    "status_emoji": ":books:",
+                                    "status_expiration": 0,
+                                    "status_text": "Print is dead",
+                                    "team": "T012AB3C4"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.profile.set method",
@@ -21771,6 +25414,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_profile",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.profile.set method",
@@ -21861,6 +25510,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setActive method",
@@ -21878,6 +25532,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setActive method",
@@ -21983,6 +25643,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setPhoto method",
@@ -22054,6 +25719,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setPhoto method",
@@ -22160,6 +25831,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setPresence method",
@@ -22177,6 +25853,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setPresence method",
@@ -22274,6 +25956,52 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the opened view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AA4928AQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "a_block_id",
+                                            "element": {
+                                                "action_id": "an_action_id",
+                                                "type": "plain_text_input"
+                                            },
+                                            "label": {
+                                                "emoji": true,
+                                                "text": "A simple label",
+                                                "type": "plain_text"
+                                            },
+                                            "optional": false,
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "bot_id": "BA13894H",
+                                    "callback_id": "identify_your_modals",
+                                    "clear_on_close": false,
+                                    "external_id": "",
+                                    "hash": "156772938.1827394",
+                                    "id": "VMHU10V25",
+                                    "notify_on_close": false,
+                                    "private_metadata": "Shh it is a secret",
+                                    "root_view_id": "VMHU10V25",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": {
+                                        "text": "Create",
+                                        "type": "plain_text"
+                                    },
+                                    "team_id": "T8N4K1JN",
+                                    "title": {
+                                        "text": "Quite a plain modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22291,6 +26019,17 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "invalid `trigger_id`"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22365,6 +26104,42 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the published view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AA4928AQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "2WGp9",
+                                            "text": {
+                                                "text": "A simple section with some sample sentence.",
+                                                "type": "mrkdwn",
+                                                "verbatim": false
+                                            },
+                                            "type": "section"
+                                        }
+                                    ],
+                                    "bot_id": "BA13894H",
+                                    "callback_id": "identify_your_home_tab",
+                                    "clear_on_close": false,
+                                    "close": null,
+                                    "external_id": "",
+                                    "hash": "156772938.1827394",
+                                    "id": "VMHU10V25",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "Shh it is a secret",
+                                    "root_view_id": "VMHU10V25",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": null,
+                                    "team_id": "T8N4K1JN",
+                                    "type": "home"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22382,6 +26157,17 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "invalid `user_id`"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22450,6 +26236,58 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the pushed view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AAD3351BQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "edit_details",
+                                            "element": {
+                                                "action_id": "detail_input",
+                                                "type": "plain_text_input"
+                                            },
+                                            "label": {
+                                                "text": "Edit details",
+                                                "type": "plain_text"
+                                            },
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "bot_id": "BADF7A34H",
+                                    "callback_id": "view_4",
+                                    "clear_on_close": true,
+                                    "close": {
+                                        "emoji": true,
+                                        "text": "Back",
+                                        "type": "plain_text"
+                                    },
+                                    "external_id": "",
+                                    "hash": "1569362015.55b5e41b",
+                                    "id": "VNM522E2U",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "",
+                                    "root_view_id": "VNN729E3U",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": {
+                                        "emoji": true,
+                                        "text": "Save",
+                                        "type": "plain_text"
+                                    },
+                                    "team_id": "T9M4RL1JM",
+                                    "title": {
+                                        "emoji": true,
+                                        "text": "Pushed Modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22467,6 +26305,17 @@
                     },
                     "default": {
                         "description": "Typical error response.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "missing required field: title"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22545,6 +26394,59 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the updated view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AAD3351BQ",
+                                    "blocks": [
+                                        {
+                                            "accessory": {
+                                                "action_id": "button_4",
+                                                "text": {
+                                                    "text": "Click me",
+                                                    "type": "plain_text"
+                                                },
+                                                "type": "button"
+                                            },
+                                            "block_id": "s_block",
+                                            "text": {
+                                                "emoji": true,
+                                                "text": "I am but an updated modal",
+                                                "type": "plain_text"
+                                            },
+                                            "type": "section"
+                                        }
+                                    ],
+                                    "bot_id": "BADF7A34H",
+                                    "callback_id": "view_2",
+                                    "clear_on_close": true,
+                                    "close": {
+                                        "emoji": true,
+                                        "text": "Close",
+                                        "type": "plain_text"
+                                    },
+                                    "external_id": "",
+                                    "hash": "1569262015.55b5e41b",
+                                    "id": "VNM522E2U",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "",
+                                    "root_view_id": "VNN729E3U",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": null,
+                                    "team_id": "T9M4RL1JM",
+                                    "title": {
+                                        "emoji": true,
+                                        "text": "Updated Modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22562,6 +26464,12 @@
                     },
                     "default": {
                         "description": "Typical error response.",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22629,6 +26537,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22646,6 +26559,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22714,6 +26633,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22731,6 +26655,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22816,6 +26746,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22833,6 +26768,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",

--- a/resources/slack-openapi-sorted.json
+++ b/resources/slack-openapi-sorted.json
@@ -2349,6 +2349,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2366,6 +2371,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2443,6 +2454,56 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "approved_apps": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://myteam.enterprise.slack.com/apps/A0W7UKG8E-my-test-app",
+                                            "app_homepage_url": "https://www.slack.com",
+                                            "description": "test app",
+                                            "help_url": "https://www.slack.com",
+                                            "icons": {
+                                                "image_1024": "https://3026743124446w96_2bd4ea1ad1f89a23c242_1024.png",
+                                                "image_128": "https://30267341249446w6_2bd4ea1ad1f89a23c242_128.png",
+                                                "image_192": "https://30267431249446w6_2bd4ea1ad1f89a23c242_192.png",
+                                                "image_32": "https://302674312496446w_2bd4ea1ad1f89a23c242_32.png",
+                                                "image_36": "https://302674312496446w_2bd4ea1ad1f89a23c242_36.png",
+                                                "image_48": "https://302674312496446w_2bd4ea1ad1f89a23c242_48.png",
+                                                "image_512": "https://30267431249446w6_2bd4ea1ad1f89a23c242_512.png",
+                                                "image_64": "https://302674312496446w_2bd4ea1ad1f89a23c242_64.png",
+                                                "image_72": "https://302674312496446w_2bd4ea1ad1f89a23c242_72.png",
+                                                "image_96": "https://302674312496446w_2bd4ea1ad1f89a23c242_96.png",
+                                                "image_original": "https://302674446w12496_2bd4ea1ad1f89a23c242_original.png"
+                                            },
+                                            "id": "A0W7UKG8E",
+                                            "is_app_directory_approved": false,
+                                            "is_internal": false,
+                                            "name": "My Test App",
+                                            "privacy_policy_url": "https://www.slack.com"
+                                        },
+                                        "date_updated": 1574296707,
+                                        "last_resolved_by": {
+                                            "actor_id": "W0G82F4FD",
+                                            "actor_type": "user"
+                                        },
+                                        "scopes": [
+                                            {
+                                                "description": "Add the ability for people to direct message or mention @my_test_app",
+                                                "is_sensitive": true,
+                                                "name": "bot",
+                                                "token_type": "bot"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2460,6 +2521,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2532,6 +2599,64 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "app_requests": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://acmecorp.slack.com/apps/A061BL8RQ0-test-app",
+                                            "app_homepage_url": "",
+                                            "description": "",
+                                            "help_url": "",
+                                            "icons": {
+                                                "image_1024": "/cdn/15258203/img/testapp/service_1024.png",
+                                                "image_128": "/cdn/157258203/img/testapp/service_128.png",
+                                                "image_192": "/cdn/157258203/img/testapp/service_192.png",
+                                                "image_32": "/cdn/157658203/img/testapp/service_32.png",
+                                                "image_36": "/cdn/157658203/img/testapp/service_36.png",
+                                                "image_48": "/cdn/157658203/img/testapp/service_48.png",
+                                                "image_512": "/cdn/15758203/img/testapp/service_512.png",
+                                                "image_64": "/cdn/157658203/img/testapp/service_64.png",
+                                                "image_72": "/cdn/157658203/img/testapp/service_72.png",
+                                                "image_96": "/cdn/157658203/img/testapp/service_96.png"
+                                            },
+                                            "id": "A061BL8RQ0",
+                                            "is_app_directory_approved": true,
+                                            "is_internal": false,
+                                            "name": "Test App",
+                                            "privacy_policy_url": "https://testapp.com/privacy"
+                                        },
+                                        "date_created": 1578956327,
+                                        "id": "Ar0XJGFLMLS",
+                                        "message": "test test again",
+                                        "previous_resolution": null,
+                                        "scopes": [
+                                            {
+                                                "description": "Post messages to specific channels in Slack",
+                                                "is_sensitive": false,
+                                                "name": "incoming-webhook",
+                                                "token_type": "user"
+                                            }
+                                        ],
+                                        "team": {
+                                            "domain": "acmecorp",
+                                            "id": "T0M94LNUCR",
+                                            "name": "Acme Corp"
+                                        },
+                                        "user": {
+                                            "email": "janedoe@example.com",
+                                            "id": "W08RA9G5HR",
+                                            "name": "Jane Doe"
+                                        }
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2549,6 +2674,14 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "missing_scope",
+                                "needed": "admin.apps:read",
+                                "ok": false,
+                                "provided": "read,client,admin,identify,post,apps"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2622,6 +2755,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2639,6 +2777,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2716,6 +2860,56 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                },
+                                "restricted_apps": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://myteam.enterprise.slack.com/apps/A0FDLP8M2L-my-test-app",
+                                            "app_homepage_url": "https://example.com",
+                                            "description": "A fun test app for Slack",
+                                            "help_url": "https://example.com",
+                                            "icons": {
+                                                "image_1024": "https://1433265338rl878408_eb57dbc818daa4ba15d6_1024.png",
+                                                "image_128": "https://4332653438rl87808_eb57dbc818daa4ba15d6_128.png",
+                                                "image_192": "https://4332653438rl87808_eb57dbc818daa4ba15d6_192.png",
+                                                "image_32": "https://143326534038rl8788_eb57dbc818daa4ba15d6_32.png",
+                                                "image_36": "https://143326534038rl8788_eb57dbc818daa4ba15d6_36.png",
+                                                "image_48": "https://143326534038rl8788_eb57dbc818daa4ba15d6_48.png",
+                                                "image_512": "https://4332653438rl87808_eb57dbc818daa4ba15d6_512.png",
+                                                "image_64": "https://143326534038rl8788_eb57dbc818daa4ba15d6_64.png",
+                                                "image_72": "https://143326534038rl8788_eb57dbc818daa4ba15d6_72.png",
+                                                "image_96": "https://143326534038rl8788_eb57dbc818daa4ba15d6_96.png",
+                                                "image_original": "https://143338rl8782653408_eb57dbc818daa4ba15d6_original.png"
+                                            },
+                                            "id": "A0FDLP8M2L",
+                                            "is_app_directory_approved": true,
+                                            "is_internal": false,
+                                            "name": "My Test App",
+                                            "privacy_policy_url": "https://example.com"
+                                        },
+                                        "date_updated": 1574296721,
+                                        "last_resolved_by": {
+                                            "actor_id": "W0G82LMFD",
+                                            "actor_type": "user"
+                                        },
+                                        "scopes": [
+                                            {
+                                                "description": "Upload, edit, and delete files on the user\u201fs behalf",
+                                                "is_sensitive": true,
+                                                "name": "files:write:user",
+                                                "token_type": "user"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2733,6 +2927,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2796,6 +2996,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.archive",
@@ -2813,6 +3018,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.archive",
@@ -2890,6 +3101,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.convertToPrivate",
@@ -2907,6 +3123,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.convertToPrivate",
@@ -3010,6 +3232,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel_id": "C12345",
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.create",
@@ -3030,6 +3258,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.create",
@@ -3107,6 +3341,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.delete",
@@ -3124,6 +3363,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.delete",
@@ -3207,6 +3452,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.disconnectShared",
@@ -3224,6 +3474,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.disconnectShared",
@@ -3322,6 +3578,19 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "id": "string",
+                                        "internal_team_ids": "array",
+                                        "original_connected_channel_id": "string",
+                                        "original_connected_host_id": "string"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3339,6 +3608,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3402,6 +3677,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.getConversationPrefs",
@@ -3458,6 +3738,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.getConversationPrefs",
@@ -3547,6 +3833,15 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "teams": [
+                                    "T1234",
+                                    "T5678"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.getTeams",
@@ -3583,6 +3878,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.getTeams",
@@ -3667,6 +3968,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.invite",
@@ -3684,6 +3990,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for error response from admin.conversations.invite",
@@ -3766,6 +4078,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.rename",
@@ -3783,6 +4100,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.rename",
@@ -3871,6 +4194,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3888,6 +4216,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3955,6 +4289,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "group_ids": [
+                                    "YOUR_GROUP_ID"
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3972,6 +4314,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4048,6 +4396,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4065,6 +4418,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4163,6 +4522,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.search",
@@ -4187,6 +4589,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_enterprise",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.search",
@@ -4273,6 +4681,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.setConversationPrefs",
@@ -4290,6 +4703,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.setConversationPrefs",
@@ -4385,6 +4804,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4402,6 +4826,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4465,6 +4895,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.unarchive",
@@ -4482,6 +4917,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.unarchive",
@@ -4565,6 +5006,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4582,6 +5028,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4651,6 +5103,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4668,6 +5125,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4735,6 +5198,43 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "cache_ts": "1575283387.000000",
+                                "categories": [
+                                    {
+                                        "emoji_names": [
+                                            "etc etc ...",
+                                            "grin",
+                                            "grinning",
+                                            "joy"
+                                        ],
+                                        "name": "Smileys & People"
+                                    }
+                                ],
+                                "categories_version": "5",
+                                "emoji": {
+                                    "black_square": "alias:black_large_square",
+                                    "bowtie": "https://emoji.slack-edge.com/T9TK3CUKW/bowtie/f3ec6f2bb0.png",
+                                    "cubimal_chick": "https://emoji.slack-edge.com/T9TK3CUKW/cubimal_chick/85961c43d7.png",
+                                    "dusty_stick": "https://emoji.slack-edge.com/T9TK3CUKW/dusty_stick/6177a62312.png",
+                                    "glitch_crab": "https://emoji.slack-edge.com/T9TK3CUKW/glitch_crab/db049f1f9c.png",
+                                    "piggy": "https://emoji.slack-edge.com/T9TK3CUKW/piggy/b7762ee8cd.png",
+                                    "pride": "https://emoji.slack-edge.com/T9TK3CUKW/pride/56b1bd3388.png",
+                                    "shipit": "alias:squirrel",
+                                    "simple_smile": {
+                                        "apple": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/apple/simple_smile.png",
+                                        "google": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/google/simple_smile.png"
+                                    },
+                                    "slack": "https://emoji.slack-edge.com/T9TK3CUKW/slack/7d462d2443.png",
+                                    "slack_call": "https://emoji.slack-edge.com/T9TK3CUKW/slack_call/b81fffd6dd.png",
+                                    "squirrel": "https://emoji.slack-edge.com/T9TK3CUKW/squirrel/465f40c0e0.png",
+                                    "thumbsup_all": "https://emoji.slack-edge.com/T9TK3CUKW/thumbsup_all/50096a1020.gif",
+                                    "white_square": "alias:white_large_square"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4752,6 +5252,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4814,6 +5320,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4831,6 +5342,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4900,6 +5417,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4917,6 +5439,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4986,6 +5514,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5003,6 +5536,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5077,6 +5616,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5094,6 +5638,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5168,6 +5718,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5185,6 +5740,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5254,6 +5815,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5271,6 +5837,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5345,6 +5917,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5362,6 +5939,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5435,6 +6018,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "admin_ids": [
+                                    "U1234"
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5452,6 +6043,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5534,6 +6131,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": "T12345"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5551,6 +6154,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5619,6 +6228,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "teams": [
+                                    {
+                                        "discoverability": "hidden",
+                                        "id": "T1234",
+                                        "name": "My Team",
+                                        "primary_owner": {
+                                            "email": "bront@slack.com",
+                                            "user_id": "W1234"
+                                        },
+                                        "team_url": "https://subarachnoid.slack.com/"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5636,6 +6262,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5709,6 +6341,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "owner_ids": [
+                                    "U1234"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5726,6 +6366,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5788,6 +6434,21 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "default_channels": "array",
+                                    "domain": "string",
+                                    "email_domain": "string",
+                                    "enterprise_id": "string",
+                                    "enterprise_name": "string",
+                                    "icon": "array",
+                                    "id": "string",
+                                    "name": "string"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5805,6 +6466,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5874,6 +6541,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5891,6 +6563,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5961,6 +6639,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5978,6 +6661,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6048,6 +6737,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6065,6 +6759,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6134,6 +6834,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6151,6 +6856,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6221,6 +6932,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6238,6 +6954,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6314,6 +7036,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6331,6 +7058,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6407,6 +7140,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6424,6 +7162,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6499,6 +7243,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "id": "C024BE91L",
+                                        "name": "fun",
+                                        "num_members": 34,
+                                        "team_id": "T024BE911"
+                                    },
+                                    {
+                                        "id": "C024BE91K",
+                                        "name": "more fun",
+                                        "team_id": "T024BE912"
+                                    },
+                                    {
+                                        "id": "C024BE91M",
+                                        "is_redacted": true,
+                                        "name": "public-channel",
+                                        "num_members": 34,
+                                        "team_id": "T024BE911"
+                                    },
+                                    {
+                                        "id": "C024BE91N",
+                                        "name": "some more fun",
+                                        "team_id": "T024BE921"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6516,6 +7290,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6586,6 +7366,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6603,6 +7388,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6691,6 +7482,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6708,6 +7504,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6821,6 +7623,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6838,6 +7645,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6913,6 +7726,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": [
+                                    {
+                                        "email": "bront@slack.com",
+                                        "id": "T1234",
+                                        "is_admin": false,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6930,6 +7760,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7000,6 +7836,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7017,6 +7858,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7086,6 +7933,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7103,6 +7955,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7178,6 +8036,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7195,6 +8058,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7265,6 +8134,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7282,6 +8156,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7359,6 +8239,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7376,6 +8261,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7446,6 +8337,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7463,6 +8359,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7533,6 +8435,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7550,6 +8457,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7611,6 +8524,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -7630,6 +8548,15 @@
                     },
                     "default": {
                         "description": "Artificial error response",
+                        "examples": {
+                            "application/json": {
+                                "args": {
+                                    "error": "my_error"
+                                },
+                                "error": "my_error",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -7707,6 +8634,17 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "authorizations": {
+                                    "enterprise_id": "string",
+                                    "is_bot": "string",
+                                    "team_id": "string",
+                                    "user_id": "string"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7724,6 +8662,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7778,6 +8722,62 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "info": {
+                                    "app_home": {
+                                        "resources": {
+                                            "ids": [
+                                                "D0BH95DLH",
+                                                "D0C0NU1Q8"
+                                            ]
+                                        },
+                                        "scopes": [
+                                            "chat:write",
+                                            "im:history",
+                                            "im:read"
+                                        ]
+                                    },
+                                    "channel": {
+                                        "resources": {
+                                            "excluded_ids": [],
+                                            "ids": [
+                                                "C061FA5PB"
+                                            ],
+                                            "wildcard": false
+                                        },
+                                        "scopes": [
+                                            "channels:read"
+                                        ]
+                                    },
+                                    "group": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "im": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "mpim": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "team": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    }
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.permissions.info method",
@@ -7879,6 +8879,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.info method",
@@ -7977,6 +8983,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.permissions.request method",
@@ -7994,6 +9005,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when trigger_id is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_trigger_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.request method",
@@ -8094,6 +9111,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "resources": [
+                                    {
+                                        "id": "T0DES3UAN",
+                                        "type": "team"
+                                    },
+                                    {
+                                        "id": "D024BFF1M",
+                                        "type": "app_home"
+                                    },
+                                    {
+                                        "id": "C024BE91L",
+                                        "type": "channel"
+                                    }
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response apps.permissions.resources.list method",
@@ -8152,6 +9191,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.resources.list method",
@@ -8237,6 +9282,35 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "scopes": {
+                                    "app_home": [
+                                        "chat:write",
+                                        "im:history",
+                                        "im:read"
+                                    ],
+                                    "channel": [
+                                        "channels:history",
+                                        "chat:write"
+                                    ],
+                                    "group": [
+                                        "chat:write"
+                                    ],
+                                    "im": [
+                                        "chat:write"
+                                    ],
+                                    "mpim": [
+                                        "chat:write"
+                                    ],
+                                    "team": [
+                                        "users:read"
+                                    ],
+                                    "user": []
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response api.permissions.scopes.list method",
@@ -8282,6 +9356,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.scopes.list method",
@@ -8378,6 +9458,29 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "resources": [
+                                    {
+                                        "id": "U0DES3UAN",
+                                        "scopes": [
+                                            "dnd:write:user",
+                                            "reminders:write:user"
+                                        ]
+                                    },
+                                    {
+                                        "id": "U024BFF1M",
+                                        "scopes": [
+                                            "reminders:write:user"
+                                        ]
+                                    }
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTdPMUg5UkFTT0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8395,6 +9498,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8471,6 +9580,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8488,6 +9602,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when trigger_id is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_trigger_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8554,6 +9674,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.uninstall method",
@@ -8571,6 +9696,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.uninstall method",
@@ -8663,6 +9794,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "revoked": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from auth.revoke method",
@@ -8684,6 +9821,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from auth.revoke method",
@@ -8767,6 +9910,16 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": "Subarachnoid Workspace",
+                                "team_id": "T12345678",
+                                "url": "https://subarachnoid.slack.com/",
+                                "user": "grace",
+                                "user_id": "W12345678"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response auth.test method",
@@ -8810,6 +9963,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response auth.test method",
@@ -8894,6 +10053,24 @@
                 "responses": {
                     "200": {
                         "description": "When successful, returns bot info by bot ID.",
+                        "examples": {
+                            "application/json": {
+                                "bot": {
+                                    "app_id": "A161CLERW",
+                                    "deleted": false,
+                                    "icons": {
+                                        "image_36": "https://...",
+                                        "image_48": "https://...",
+                                        "image_72": "https://..."
+                                    },
+                                    "id": "B061F7JD2",
+                                    "name": "beforebot",
+                                    "updated": 1449272004,
+                                    "user_id": "U012ABCDEF"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from bots.info method",
@@ -8967,6 +10144,12 @@
                     },
                     "default": {
                         "description": "When no bot can be found, it returns an error.",
+                        "examples": {
+                            "application/json": {
+                                "error": "bot_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from bots.info method",
@@ -9101,6 +10284,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9118,6 +10306,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9186,6 +10380,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9203,6 +10402,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9265,6 +10470,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9282,6 +10492,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9351,6 +10567,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9368,6 +10589,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9438,6 +10665,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9455,6 +10687,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9536,6 +10774,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9553,6 +10796,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9625,6 +10874,13 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE91L",
+                                "ok": true,
+                                "ts": "1401383885.000061"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.delete method",
@@ -9650,6 +10906,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "message_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.delete method",
@@ -9757,6 +11019,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.deleteScheduledMessage method",
@@ -9774,6 +11041,12 @@
                     },
                     "default": {
                         "description": "Typical error response if no message is found",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_scheduled_message_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.deleteScheduledMessage method",
@@ -9876,6 +11149,13 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGA",
+                                "ok": true,
+                                "permalink": "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response chat.getPermalink",
@@ -9902,6 +11182,12 @@
                     },
                     "default": {
                         "description": "Error response when channel cannot be found",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.getPermalink method",
@@ -9998,6 +11284,13 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE7LR",
+                                "ok": true,
+                                "ts": "1417671948.000006"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.meMessage method",
@@ -10021,6 +11314,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.meMessage method",
@@ -10185,6 +11484,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "message_ts": "1502210682.580145",
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.postEphemeral method",
@@ -10206,6 +11511,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_in_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.postEphemeral method",
@@ -10388,6 +11699,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGL",
+                                "message": {
+                                    "attachments": [
+                                        {
+                                            "fallback": "This is an attachment's fallback",
+                                            "id": 1,
+                                            "text": "This is an attachment"
+                                        }
+                                    ],
+                                    "bot_id": "B19LU7CSY",
+                                    "subtype": "bot_message",
+                                    "text": "Here's a message for you",
+                                    "ts": "1503435956.000247",
+                                    "type": "message",
+                                    "username": "ecto1"
+                                },
+                                "ok": true,
+                                "ts": "1503435956.000247"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.postMessage method",
@@ -10417,6 +11750,12 @@
                     },
                     "default": {
                         "description": "Typical error response if too many attachments are included",
+                        "examples": {
+                            "application/json": {
+                                "error": "too_many_attachments",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.postMessage method",
@@ -10570,6 +11909,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGL",
+                                "message": {
+                                    "attachments": [
+                                        {
+                                            "fallback": "This is an attachment's fallback",
+                                            "id": 1,
+                                            "text": "This is an attachment"
+                                        }
+                                    ],
+                                    "bot_id": "B19LU7CSY",
+                                    "subtype": "bot_message",
+                                    "text": "Here's a message for you in the future",
+                                    "type": "delayed_message",
+                                    "username": "ecto1"
+                                },
+                                "ok": true,
+                                "post_at": "1562180400",
+                                "scheduled_message_id": "Q1298393284"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.scheduleMessage method",
@@ -10637,6 +11998,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the `post_at` is invalid (ex. in the past or too far into the future)",
+                        "examples": {
+                            "application/json": {
+                                "error": "time_in_past",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.scheduleMessage method",
@@ -10766,6 +12133,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                },
+                                "scheduled_messages": [
+                                    {
+                                        "channel_id": "C1H9RESGL",
+                                        "date_created": 1551891734,
+                                        "id": 1298393284,
+                                        "post_at": 1551991428,
+                                        "text": "Here's a message for you in the future"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.scheduledMessages.list method",
@@ -10830,6 +12214,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the channel passed is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.scheduledMessages.list method",
@@ -10955,6 +12345,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical, minimal success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.unfurl method",
@@ -10972,6 +12367,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "cannot_unfurl_url",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.unfurl method",
@@ -11110,6 +12511,18 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE91L",
+                                "message": {
+                                    "text": "Updated text you carefully authored",
+                                    "user": "U34567890"
+                                },
+                                "ok": true,
+                                "text": "Updated text you carefully authored",
+                                "ts": "1401383885.000061"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.update method",
@@ -11161,6 +12574,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_update_message",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.update method",
@@ -11257,6 +12676,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.archive method",
@@ -11274,6 +12698,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.archive method",
@@ -11379,6 +12809,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.close method",
@@ -11402,6 +12837,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.close method",
@@ -11505,6 +12946,48 @@
                 "responses": {
                     "200": {
                         "description": "If successful, the command returns a rather stark [conversation object](/types/conversation)",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1504554479,
+                                    "creator": "U0123456",
+                                    "id": "C0EAQDV4Z",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": false,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_shared": false,
+                                    "last_read": "0000000000.000000",
+                                    "latest": null,
+                                    "name": "endeavor",
+                                    "name_normalized": "endeavor",
+                                    "pending_shared": [],
+                                    "previous_names": [],
+                                    "priority": 0,
+                                    "purpose": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": ""
+                                    },
+                                    "topic": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": ""
+                                    },
+                                    "unlinked": 0,
+                                    "unread_count": 0,
+                                    "unread_count_display": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.create method",
@@ -11526,6 +13009,12 @@
                     },
                     "default": {
                         "description": "Typical error response when name already in use",
+                        "examples": {
+                            "application/json": {
+                                "error": "name_taken",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.create method",
@@ -11663,6 +13152,30 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response containing a channel's messages",
+                        "examples": {
+                            "application/json": {
+                                "has_more": true,
+                                "messages": [
+                                    {
+                                        "text": "I find you punny and would like to smell your nose letter",
+                                        "ts": "1512085950.000216",
+                                        "type": "message",
+                                        "user": "U012AB3CDE"
+                                    },
+                                    {
+                                        "text": "What, you want to smell my shoes better?",
+                                        "ts": "1512104434.000490",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    }
+                                ],
+                                "ok": true,
+                                "pin_count": 0,
+                                "response_metadata": {
+                                    "next_cursor": "bmV4dF90czoxNTEyMDg1ODYxMDAwNTQz"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.history method",
@@ -11712,6 +13225,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.history method",
@@ -11819,6 +13338,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response for a public channel. (Also, a response from a private channel and a multi-party IM is very similar to this example.)",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "parent_conversation": null,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "abstractions",
+                                        "etc",
+                                        "specifics"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.info",
@@ -11840,6 +13404,12 @@
                     },
                     "default": {
                         "description": "Typical error response when a channel cannot be found",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.info method",
@@ -11941,6 +13511,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response when an invitation is extended",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "num_members": 23,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "abstractions",
+                                        "etc",
+                                        "specifics"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.invite method",
@@ -11962,6 +13577,12 @@
                     },
                     "default": {
                         "description": "Typical error response when an invite is attempted on a conversation type that does not support it",
+                        "examples": {
+                            "application/json": {
+                                "error": "method_not_supported_for_channel_type",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.invite method",
@@ -12129,6 +13750,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "U061F7AUR",
+                                    "id": "C061EG9SL",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_shared": false,
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "pending_shared": [],
+                                    "previous_names": [],
+                                    "purpose": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": "For widget discussion"
+                                    },
+                                    "topic": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": "Which widget do you worry about?"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true,
+                                "response_metadata": {
+                                    "warnings": [
+                                        "already_in_channel"
+                                    ]
+                                },
+                                "warning": "already_in_channel"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.join method",
@@ -12167,6 +13831,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the conversation is archived and cannot be joined",
+                        "examples": {
+                            "application/json": {
+                                "error": "is_archived",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.join method",
@@ -12272,6 +13942,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.kick method",
@@ -12289,6 +13964,12 @@
                     },
                     "default": {
                         "description": "Typical error response when you attempt to kick yourself from a channel",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_kick_self",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response conversations.kick method",
@@ -12391,6 +14072,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.leave method",
@@ -12414,6 +14100,12 @@
                     },
                     "default": {
                         "description": "Typical error response when attempting to leave a workspace's \"general\" channel",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_leave_general",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.leave method",
@@ -12535,6 +14227,82 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response with only public channels",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    },
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U061F7AUR",
+                                        "id": "C061EG9T2",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": false,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "random",
+                                        "name_normalized": "random",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Non-work banter and water cooler conversation"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.list method",
@@ -12572,6 +14340,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.list method",
@@ -12671,6 +14445,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.mark method",
@@ -12688,6 +14467,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.mark method",
@@ -12797,6 +14582,19 @@
                 "responses": {
                     "200": {
                         "description": "Typical paginated success response",
+                        "examples": {
+                            "application/json": {
+                                "members": [
+                                    "U023BECGF",
+                                    "U061F7AUR",
+                                    "W012A3CDE"
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "e3VzZXJfaWQ6IFcxMjM0NTY3fQ=="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.members method",
@@ -12836,6 +14634,12 @@
                     },
                     "default": {
                         "description": "Typical error response when an invalid cursor is provided",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response conversations.members method",
@@ -12939,6 +14743,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "id": "D069C7QFK"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.open method when opening channels, ims, mpims",
@@ -13006,6 +14818,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.open method",
@@ -13108,6 +14926,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "num_members": 23,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "abstractions",
+                                        "etc",
+                                        "specifics"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.rename method",
@@ -13129,6 +14992,12 @@
                     },
                     "default": {
                         "description": "Typical error response when the calling user is not a member of the conversation",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_in_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.rename method",
@@ -13268,6 +15137,52 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "has_more": true,
+                                "messages": [
+                                    {
+                                        "last_read": "1484678597.521003",
+                                        "reply_count": 3,
+                                        "subscribed": true,
+                                        "text": "island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1482960137.003543",
+                                        "type": "message",
+                                        "unread_count": 0,
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "one island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483037603.017503",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "two island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483051909.018632",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "three for the land",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483125339.020269",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "bmV4dF90czoxNDg0Njc4MjkwNTE3MDkx"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.replies method",
@@ -13410,6 +15325,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "thread_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.replies method",
@@ -13512,6 +15433,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.setPurpose method",
@@ -13533,6 +15459,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.setPurpose method",
@@ -13639,6 +15571,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.setTopic method",
@@ -13660,6 +15597,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.setTopic method",
@@ -13760,6 +15703,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.unarchive method",
@@ -13777,6 +15725,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.unarchive method",
@@ -13888,6 +15842,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response is quite minimal.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dialog.open method",
@@ -13905,6 +15864,12 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "missing_trigger",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dialog.open method",
@@ -13997,6 +15962,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.endDnd method",
@@ -14014,6 +15984,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.endDnd method",
@@ -14099,6 +16075,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.endSnooze method",
@@ -14132,6 +16113,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.endSnooze method",
@@ -14222,6 +16209,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.info method",
@@ -14260,6 +16252,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.info method",
@@ -14350,6 +16348,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.setSnooze method",
@@ -14379,6 +16382,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.setSnooze method",
@@ -14470,6 +16479,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": {
+                                    "U023BECGF": {
+                                        "dnd_enabled": true,
+                                        "next_dnd_end_ts": 1450423800,
+                                        "next_dnd_start_ts": 1450387800
+                                    },
+                                    "W058CJVAA": {
+                                        "dnd_enabled": false,
+                                        "next_dnd_end_ts": 1,
+                                        "next_dnd_start_ts": 1
+                                    }
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -14487,6 +16513,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -14541,6 +16573,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -14558,6 +16595,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -14624,6 +16667,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response is very simple",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.comments.delete method",
@@ -14641,6 +16689,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "file_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.comments.delete method",
@@ -14728,6 +16782,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.delete method",
@@ -14745,6 +16804,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.delete method",
@@ -14854,6 +16919,77 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "comments": [],
+                                "file": {
+                                    "channels": [
+                                        "C0T8SE4AU"
+                                    ],
+                                    "comments_count": 0,
+                                    "created": 1531763342,
+                                    "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+                                    "display_as_bot": false,
+                                    "editable": false,
+                                    "external_type": "",
+                                    "filetype": "gif",
+                                    "groups": [],
+                                    "has_rich_preview": false,
+                                    "id": "F0S43PZDF",
+                                    "image_exif_rotation": 1,
+                                    "ims": [],
+                                    "is_external": false,
+                                    "is_public": true,
+                                    "is_starred": false,
+                                    "mimetype": "image/gif",
+                                    "mode": "hosted",
+                                    "name": "tedair.gif",
+                                    "original_h": 226,
+                                    "original_w": 176,
+                                    "permalink": "https://.../tedair.gif",
+                                    "permalink_public": "https://.../...",
+                                    "pjpeg": "https://.../tedair_pjpeg.jpg",
+                                    "pretty_type": "GIF",
+                                    "public_url_shared": false,
+                                    "shares": {
+                                        "public": {
+                                            "C0T8SE4AU": [
+                                                {
+                                                    "channel_name": "file-under",
+                                                    "latest_reply": "1531763348.000001",
+                                                    "reply_count": 1,
+                                                    "reply_users": [
+                                                        "U061F7AUR"
+                                                    ],
+                                                    "reply_users_count": 1,
+                                                    "team_id": "T061EG9R6",
+                                                    "thread_ts": "1531763273.000015",
+                                                    "ts": "1531763348.000001"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "size": 137531,
+                                    "thumb_160": "https://.../tedair_=_160.png",
+                                    "thumb_360": "https://.../tedair_360.png",
+                                    "thumb_360_gif": "https://.../tedair_360.gif",
+                                    "thumb_360_h": 226,
+                                    "thumb_360_w": 176,
+                                    "thumb_64": "https://.../tedair_64.png",
+                                    "thumb_80": "https://.../tedair_80.png",
+                                    "timestamp": 1531763342,
+                                    "title": "tedair.gif",
+                                    "url_private": "https://.../tedair.gif",
+                                    "url_private_download": "https://.../tedair.gif",
+                                    "user": "U061F7AUR",
+                                    "username": ""
+                                },
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.info method",
@@ -14891,6 +17027,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.info method",
@@ -15018,6 +17160,103 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "files": [
+                                    {
+                                        "channels": [
+                                            "C0T8SE4AU"
+                                        ],
+                                        "comments_count": 0,
+                                        "created": 1531763254,
+                                        "deanimate_gif": "https://.../billair_deanimate_gif.png",
+                                        "display_as_bot": false,
+                                        "editable": false,
+                                        "external_type": "",
+                                        "filetype": "gif",
+                                        "groups": [],
+                                        "id": "F0S43P1CZ",
+                                        "image_exif_rotation": 1,
+                                        "ims": [],
+                                        "is_external": false,
+                                        "is_public": true,
+                                        "mimetype": "image/gif",
+                                        "mode": "hosted",
+                                        "name": "billair.gif",
+                                        "original_h": 226,
+                                        "original_w": 176,
+                                        "permalink": "https://.../billair.gif",
+                                        "permalink_public": "https://.../...",
+                                        "pjpeg": "https://.../billair_pjpeg.jpg",
+                                        "pretty_type": "GIF",
+                                        "public_url_shared": false,
+                                        "size": 144538,
+                                        "thumb_160": "https://.../billair_=_160.png",
+                                        "thumb_360": "https://.../billair_360.png",
+                                        "thumb_360_gif": "https://.../billair_360.gif",
+                                        "thumb_360_h": 226,
+                                        "thumb_360_w": 176,
+                                        "thumb_64": "https://.../billair_64.png",
+                                        "thumb_80": "https://.../billair_80.png",
+                                        "timestamp": 1531763254,
+                                        "title": "billair.gif",
+                                        "url_private": "https://.../billair.gif",
+                                        "url_private_download": "https://.../billair.gif",
+                                        "user": "U061F7AUR",
+                                        "username": ""
+                                    },
+                                    {
+                                        "channels": [
+                                            "C0T8SE4AU"
+                                        ],
+                                        "comments_count": 0,
+                                        "created": 1531763342,
+                                        "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+                                        "display_as_bot": false,
+                                        "editable": false,
+                                        "external_type": "",
+                                        "filetype": "gif",
+                                        "groups": [],
+                                        "id": "F0S43PZDF",
+                                        "image_exif_rotation": 1,
+                                        "ims": [],
+                                        "is_external": false,
+                                        "is_public": true,
+                                        "mimetype": "image/gif",
+                                        "mode": "hosted",
+                                        "name": "tedair.gif",
+                                        "original_h": 226,
+                                        "original_w": 176,
+                                        "permalink": "https://.../tedair.gif",
+                                        "permalink_public": "https://.../...",
+                                        "pjpeg": "https://.../tedair_pjpeg.jpg",
+                                        "pretty_type": "GIF",
+                                        "public_url_shared": false,
+                                        "size": 137531,
+                                        "thumb_160": "https://.../tedair_=_160.png",
+                                        "thumb_360": "https://.../tedair_360.png",
+                                        "thumb_360_gif": "https://.../tedair_360.gif",
+                                        "thumb_360_h": 226,
+                                        "thumb_360_w": 176,
+                                        "thumb_64": "https://.../tedair_64.png",
+                                        "thumb_80": "https://.../tedair_80.png",
+                                        "timestamp": 1531763342,
+                                        "title": "tedair.gif",
+                                        "url_private": "https://.../tedair.gif",
+                                        "url_private_download": "https://.../tedair.gif",
+                                        "user": "U061F7AUR",
+                                        "username": ""
+                                    }
+                                ],
+                                "ok": true,
+                                "paging": {
+                                    "count": 100,
+                                    "page": 1,
+                                    "pages": 1,
+                                    "total": 2
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.list method",
@@ -15048,6 +17287,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.list method",
@@ -15165,6 +17410,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15182,6 +17432,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15248,6 +17504,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15265,6 +17526,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15349,6 +17616,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15366,6 +17638,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15432,6 +17710,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15449,6 +17732,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15521,6 +17810,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15538,6 +17832,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15634,6 +17934,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15651,6 +17956,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15712,6 +18023,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.revokePublicURL method",
@@ -15733,6 +18049,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.revokePublicURL method",
@@ -15824,6 +18146,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.sharedPublicURL method",
@@ -15845,6 +18172,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.sharedPublicURL method",
@@ -15978,6 +18311,67 @@
                 "responses": {
                     "200": {
                         "description": "Success response after uploading a file to a channel with an initial message",
+                        "examples": {
+                            "application/json": {
+                                "file": {
+                                    "channels": [],
+                                    "comments_count": 0,
+                                    "created": 1532293501,
+                                    "display_as_bot": false,
+                                    "editable": false,
+                                    "external_type": "",
+                                    "filetype": "gif",
+                                    "groups": [],
+                                    "has_rich_preview": false,
+                                    "id": "F0TD00400",
+                                    "image_exif_rotation": 1,
+                                    "ims": [
+                                        "D0L4B9P0Q"
+                                    ],
+                                    "is_external": false,
+                                    "is_public": false,
+                                    "is_starred": false,
+                                    "mimetype": "image/jpeg",
+                                    "mode": "hosted",
+                                    "name": "dramacat.gif",
+                                    "original_h": 366,
+                                    "original_w": 526,
+                                    "permalink": "https://.../dramacat.gif",
+                                    "permalink_public": "https://.../More-Path-Components",
+                                    "pretty_type": "JPEG",
+                                    "public_url_shared": false,
+                                    "shares": {
+                                        "private": {
+                                            "D0L4B9P0Q": [
+                                                {
+                                                    "reply_count": 0,
+                                                    "reply_users": [],
+                                                    "reply_users_count": 0,
+                                                    "ts": "1532293503.000001"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "size": 43518,
+                                    "thumb_160": "https://.../dramacat_160.gif",
+                                    "thumb_360": "https://.../dramacat_360.gif",
+                                    "thumb_360_h": 250,
+                                    "thumb_360_w": 360,
+                                    "thumb_480": "https://.../dramacat_480.gif",
+                                    "thumb_480_h": 334,
+                                    "thumb_480_w": 480,
+                                    "thumb_64": "https://.../dramacat_64.gif",
+                                    "thumb_80": "https://.../dramacat_80.gif",
+                                    "timestamp": 1532293501,
+                                    "title": "dramacat",
+                                    "url_private": "https://.../dramacat.gif",
+                                    "url_private_download": "https://.../dramacat.gif",
+                                    "user": "U0L4B9NSU",
+                                    "username": ""
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.upload method",
@@ -15999,6 +18393,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.upload method",
@@ -16010,7 +18410,6 @@
                                 "error": {
                                     "enum": [
                                         "account_inactive",
-                                        "file_upload_size_restricted",
                                         "file_uploads_disabled",
                                         "file_uploads_except_images_disabled",
                                         "invalid_arg_name",
@@ -16103,6 +18502,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response when mappings exist for the specified user IDs",
+                        "examples": {
+                            "application/json": {
+                                "enterprise_id": "E1KQTNXE1",
+                                "invalid_user_ids": [
+                                    "U21ABZZXX"
+                                ],
+                                "ok": true,
+                                "team_id": "T1KR7PE1W",
+                                "user_id_map": {
+                                    "U06UBSUN5": "W06M56XJM",
+                                    "U06UBSVB3": "W06PUUDLY",
+                                    "U06UBSVDX": "W06PUUDMW",
+                                    "U06UEB62U": "W06PTT6GH",
+                                    "W06UAZ65Q": "W06UAZ65Q"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from migration.exchange method",
@@ -16141,6 +18557,12 @@
                     },
                     "default": {
                         "description": "Typical error response when there are no mappings to provide",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_enterprise_team",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from migration.exchange method",
@@ -16248,6 +18670,15 @@
                 "responses": {
                     "200": {
                         "description": "Successful user token negotiation for a single scope",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
+                                "enterprise_id": null,
+                                "scope": "groups:write",
+                                "team_id": "TXXXXXXXXX",
+                                "team_name": "Wyld Stallyns LLC"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16265,6 +18696,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16342,6 +18779,30 @@
                 "responses": {
                     "200": {
                         "description": "Success example using a workspace app produces a very different kind of response",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxa-access-token-string",
+                                "app_id": "A012345678",
+                                "app_user_id": "U0AB12ABC",
+                                "authorizing_user_id": "U0HTT3Q0G",
+                                "installer_user_id": "U061F7AUR",
+                                "ok": true,
+                                "permissions": [
+                                    {
+                                        "resource_id": 0,
+                                        "resource_type": "channel",
+                                        "scopes": [
+                                            "channels:read",
+                                            "chat:write:user"
+                                        ]
+                                    }
+                                ],
+                                "single_channel_id": "C061EG9T2",
+                                "team_id": "T061EG9Z9",
+                                "team_name": "Subarachnoid Workspace",
+                                "token_type": "app"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16359,6 +18820,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16431,6 +18898,30 @@
                 "responses": {
                     "200": {
                         "description": "Successful token request with scopes for both a bot user and a user token",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+                                "app_id": "A0KRD7HC3",
+                                "authed_user": {
+                                    "access_token": "xoxp-1234",
+                                    "id": "U1234",
+                                    "scope": "chat:write",
+                                    "token_type": "user"
+                                },
+                                "bot_user_id": "U0KRQLJ9H",
+                                "enterprise": {
+                                    "id": "E12345678",
+                                    "name": "slack-sports"
+                                },
+                                "ok": true,
+                                "scope": "commands,incoming-webhook",
+                                "team": {
+                                    "id": "T9TK3CUKW",
+                                    "name": "Slack Softball Team"
+                                },
+                                "token_type": "bot"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16448,6 +18939,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16517,6 +19014,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from pins.add method",
@@ -16534,6 +19036,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.add method",
@@ -16628,6 +19136,45 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "items": [
+                                    {
+                                        "channel": "C2U86NC6H",
+                                        "created": 1508881078,
+                                        "created_by": "U2U85N1RZ",
+                                        "message": {
+                                            "permalink": "https://hitchhikers.slack.com/archives/C2U86NC6H/p1508197641000151",
+                                            "pinned_to": [
+                                                "C2U86NC6H"
+                                            ],
+                                            "text": "What is the meaning of life?",
+                                            "ts": "1508197641.000151",
+                                            "type": "message",
+                                            "user": "U2U85N1RZ"
+                                        },
+                                        "type": "message"
+                                    },
+                                    {
+                                        "channel": "C2U86NC6H",
+                                        "created": 1508880991,
+                                        "created_by": "U2U85N1RZ",
+                                        "message": {
+                                            "permalink": "https://hitchhikers.slack.com/archives/C2U86NC6H/p1508284197000015",
+                                            "pinned_to": [
+                                                "C2U86NC6H"
+                                            ],
+                                            "text": "The meaning of life, the universe, and everything is 42.",
+                                            "ts": "1503289197.000015",
+                                            "type": "message",
+                                            "user": "U2U85N1RZ"
+                                        },
+                                        "type": "message"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from pins.list method",
                             "items": [
@@ -16719,6 +19266,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.list method",
@@ -16813,6 +19366,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from pins.remove method",
@@ -16830,6 +19388,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "no_pin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.remove method",
@@ -16938,6 +19502,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.add method",
@@ -16955,6 +19524,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "already_reacted",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.add method",
@@ -17071,6 +19646,35 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "file": {
+                                    "channels": [
+                                        "C2U7V2YA2"
+                                    ],
+                                    "comments_count": 1,
+                                    "created": 1507850315,
+                                    "groups": [],
+                                    "id": "F7H0D7ZA4",
+                                    "ims": [],
+                                    "name": "computer.gif",
+                                    "reactions": [
+                                        {
+                                            "count": 1,
+                                            "name": "stuck_out_tongue_winking_eye",
+                                            "users": [
+                                                "U2U85N1RV"
+                                            ]
+                                        }
+                                    ],
+                                    "timestamp": 1507850315,
+                                    "title": "computer.gif",
+                                    "user": "U2U85N1RV"
+                                },
+                                "ok": true,
+                                "type": "file"
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from reactions.get method",
                             "items": [
@@ -17155,6 +19759,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.get method",
@@ -17272,6 +19882,99 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "items": [
+                                    {
+                                        "channel": "C3UKJTQAC",
+                                        "message": {
+                                            "bot_id": "B4VLRLMKJ",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "robot_face",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "subtype": "bot_message",
+                                            "text": "Hello from Python! :tada:",
+                                            "ts": "1507849573.000090",
+                                            "username": "Shipit Notifications"
+                                        },
+                                        "type": "message"
+                                    },
+                                    {
+                                        "comment": {
+                                            "comment": "This is a file comment",
+                                            "created": 1508286096,
+                                            "id": "Fc7LP08P1U",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "white_check_mark",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "timestamp": 1508286096,
+                                            "type": "file_comment",
+                                            "user": "U2U85N1RV"
+                                        },
+                                        "file": {
+                                            "channels": [
+                                                "C2U7V2YA2"
+                                            ],
+                                            "comments_count": 1,
+                                            "created": 1507850315,
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "stuck_out_tongue_winking_eye",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "title": "computer.gif",
+                                            "user": "U2U85N1RV",
+                                            "username": ""
+                                        }
+                                    },
+                                    {
+                                        "file": {
+                                            "channels": [
+                                                "C2U7V2YA2"
+                                            ],
+                                            "comments_count": 1,
+                                            "created": 1507850315,
+                                            "id": "F7H0D7ZA4",
+                                            "name": "computer.gif",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "stuck_out_tongue_winking_eye",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "size": 1639034,
+                                            "title": "computer.gif",
+                                            "user": "U2U85N1RV",
+                                            "username": ""
+                                        },
+                                        "type": "file"
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.list method",
@@ -17368,6 +20071,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.list method",
@@ -17481,6 +20190,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.remove method",
@@ -17498,6 +20212,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "no_reaction",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.remove method",
@@ -17606,6 +20326,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.add method",
@@ -17627,6 +20352,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.add method",
@@ -17722,6 +20453,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.complete method",
@@ -17739,6 +20475,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.complete method",
@@ -17831,6 +20573,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.delete method",
@@ -17848,6 +20595,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.delete method",
@@ -17937,6 +20690,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.info method",
@@ -17958,6 +20716,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.info method",
@@ -18041,6 +20805,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.list method",
@@ -18065,6 +20834,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.list method",
@@ -18160,6 +20935,21 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "self": {
+                                    "id": "U4X318ZMZ",
+                                    "name": "robotoverlord"
+                                },
+                                "team": {
+                                    "domain": "slackdemo",
+                                    "id": "T2U81E2FP",
+                                    "name": "SlackDemo"
+                                },
+                                "url": "wss://..."
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from rtm.connect method",
@@ -18220,6 +21010,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from rtm.connect method",
@@ -18337,6 +21133,73 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "messages": {
+                                    "matches": [
+                                        {
+                                            "channel": {
+                                                "id": "C12345678",
+                                                "is_ext_shared": false,
+                                                "is_mpim": false,
+                                                "is_org_shared": false,
+                                                "is_pending_ext_shared": false,
+                                                "is_private": false,
+                                                "is_shared": false,
+                                                "name": "general",
+                                                "pending_shared": []
+                                            },
+                                            "iid": "cb64bdaa-c1e8-4631-8a91-0f78080113e9",
+                                            "permalink": "https://hitchhikers.slack.com/archives/C12345678/p1508284197000015",
+                                            "team": "T12345678",
+                                            "text": "The meaning of life the universe and everything is 42.",
+                                            "ts": "1508284197.000015",
+                                            "type": "message",
+                                            "user": "U2U85N1RV",
+                                            "username": "roach"
+                                        },
+                                        {
+                                            "channel": {
+                                                "id": "C12345678",
+                                                "is_ext_shared": false,
+                                                "is_mpim": false,
+                                                "is_org_shared": false,
+                                                "is_pending_ext_shared": false,
+                                                "is_private": false,
+                                                "is_shared": false,
+                                                "name": "random",
+                                                "pending_shared": []
+                                            },
+                                            "iid": "9a00d3c9-bd2d-45b0-988b-6cff99ae2a90",
+                                            "permalink": "https://hitchhikers.slack.com/archives/C12345678/p1508795665000236",
+                                            "team": "T12345678",
+                                            "text": "The meaning of life the universe and everything is 101010",
+                                            "ts": "1508795665.000236",
+                                            "type": "message",
+                                            "user": "",
+                                            "username": "robot overlord"
+                                        }
+                                    ],
+                                    "pagination": {
+                                        "first": 1,
+                                        "last": 2,
+                                        "page": 1,
+                                        "page_count": 1,
+                                        "per_page": 20,
+                                        "total_count": 2
+                                    },
+                                    "paging": {
+                                        "count": 20,
+                                        "page": 1,
+                                        "pages": 1,
+                                        "total": 2
+                                    },
+                                    "total": 2
+                                },
+                                "ok": true,
+                                "query": "The meaning of life the universe and everything"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -18354,6 +21217,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "No query passed",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -18433,6 +21302,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.add method",
@@ -18450,6 +21324,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.add method",
@@ -18560,6 +21440,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.list method",
@@ -18734,6 +21619,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.list method",
@@ -18842,6 +21733,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.remove method",
@@ -18859,6 +21755,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.remove method",
@@ -18964,6 +21866,43 @@
                 "responses": {
                     "200": {
                         "description": "This response demonstrates pagination and two access log entries.",
+                        "examples": {
+                            "application/json": {
+                                "logins": [
+                                    {
+                                        "count": 1,
+                                        "country": "US",
+                                        "date_first": 1422922864,
+                                        "date_last": 1422922864,
+                                        "ip": "127.0.0.1",
+                                        "isp": "BigCo ISP",
+                                        "region": "CA",
+                                        "user_agent": "SlackWeb Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.35 Safari/537.36",
+                                        "user_id": "U45678",
+                                        "username": "alice"
+                                    },
+                                    {
+                                        "count": 1,
+                                        "country": "US",
+                                        "date_first": 1422922493,
+                                        "date_last": 1422922493,
+                                        "ip": "127.0.0.1",
+                                        "isp": "BigCo ISP",
+                                        "region": "CA",
+                                        "user_agent": "SlackWeb Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4",
+                                        "user_id": "U12345",
+                                        "username": "white_rabbit"
+                                    }
+                                ],
+                                "ok": true,
+                                "paging": {
+                                    "count": 100,
+                                    "page": 1,
+                                    "pages": 1,
+                                    "total": 2
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.accessLogs method",
@@ -19051,6 +21990,12 @@
                     },
                     "default": {
                         "description": "A workspace must be on a paid plan to use this method, otherwise the `paid_only` error is thrown:",
+                        "examples": {
+                            "application/json": {
+                                "error": "paid_only",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.accessLogs method",
@@ -19142,6 +22087,22 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "billable_info": {
+                                    "U02UCPE1R": {
+                                        "billing_active": true
+                                    },
+                                    "U02UEBSD2": {
+                                        "billing_active": true
+                                    },
+                                    "U0632EWRW": {
+                                        "billing_active": false
+                                    }
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -19159,6 +22120,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -19219,6 +22186,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "domain": "example",
+                                    "email_domain": "example.com",
+                                    "enterprise_id": "E1234A12AB",
+                                    "enterprise_name": "Umbrella Corporation",
+                                    "icon": {
+                                        "image_102": "https://...",
+                                        "image_132": "https://...",
+                                        "image_34": "https://...",
+                                        "image_44": "https://...",
+                                        "image_68": "https://...",
+                                        "image_88": "https://...",
+                                        "image_default": true
+                                    },
+                                    "id": "T12345",
+                                    "name": "My Team"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.info method",
@@ -19240,6 +22229,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.info method",
@@ -19355,6 +22350,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.integrationLogs method",
@@ -19430,6 +22430,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.integrationLogs method",
@@ -19519,6 +22525,77 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "fields": [
+                                        {
+                                            "hint": "Enter the extension to reach your desk",
+                                            "id": "Xf06054AAA",
+                                            "is_hidden": 1,
+                                            "label": "Phone extension",
+                                            "options": null,
+                                            "ordering": 0,
+                                            "possible_values": null,
+                                            "type": "text"
+                                        },
+                                        {
+                                            "hint": "When you were born",
+                                            "id": "Xf06054BBB",
+                                            "label": "Date of birth",
+                                            "options": null,
+                                            "ordering": 1,
+                                            "possible_values": null,
+                                            "type": "date"
+                                        },
+                                        {
+                                            "hint": "Enter a link to your Facebook profile",
+                                            "id": "Xf06054CCC",
+                                            "label": "Facebook",
+                                            "options": null,
+                                            "ordering": 2,
+                                            "possible_values": null,
+                                            "type": "link"
+                                        },
+                                        {
+                                            "hint": "Hogwarts, obviously",
+                                            "id": "Xf06054DDD",
+                                            "label": "House",
+                                            "options": null,
+                                            "ordering": 3,
+                                            "possible_values": [
+                                                "Gryffindor",
+                                                "Hufflepuff",
+                                                "Ravenclaw",
+                                                "Slytherin"
+                                            ],
+                                            "type": "options_list"
+                                        },
+                                        {
+                                            "hint": "Office location (LDAP)",
+                                            "id": "Xf06054EEE",
+                                            "label": "Location",
+                                            "options": {
+                                                "is_protected": 1
+                                            },
+                                            "ordering": 4,
+                                            "possible_values": null,
+                                            "type": "text"
+                                        },
+                                        {
+                                            "hint": "The boss",
+                                            "id": "Xf06054FFF",
+                                            "label": "Manager",
+                                            "options": null,
+                                            "ordering": 5,
+                                            "possible_values": null,
+                                            "type": "user"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.profile.get method",
@@ -19553,6 +22630,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.profile.get method",
@@ -19666,6 +22749,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.create method",
@@ -19687,6 +22775,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.create method",
@@ -19786,6 +22880,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.disable method",
@@ -19807,6 +22906,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.disable method",
@@ -19906,6 +23011,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.enable method",
@@ -19927,6 +23037,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.enable method",
@@ -20031,6 +23147,76 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroups": [
+                                    {
+                                        "auto_type": "admin",
+                                        "created_by": "USLACKBOT",
+                                        "date_create": 1446598059,
+                                        "date_delete": 0,
+                                        "date_update": 1446670362,
+                                        "deleted_by": null,
+                                        "description": "A group of all Administrators on your team.",
+                                        "handle": "admins",
+                                        "id": "S0614TZR7",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Team Admins",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "U060RNRCZ",
+                                        "user_count": "2"
+                                    },
+                                    {
+                                        "auto_type": "owner",
+                                        "created_by": "USLACKBOT",
+                                        "date_create": 1446678371,
+                                        "date_delete": 0,
+                                        "date_update": 1446678371,
+                                        "deleted_by": null,
+                                        "description": "A group of all Owners on your team.",
+                                        "handle": "owners",
+                                        "id": "S06158AV7",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Team Owners",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "USLACKBOT",
+                                        "user_count": "1"
+                                    },
+                                    {
+                                        "auto_type": null,
+                                        "created_by": "U060RNRCZ",
+                                        "date_create": 1446746793,
+                                        "date_delete": 1446748865,
+                                        "date_update": 1446747767,
+                                        "deleted_by": null,
+                                        "description": "Marketing gurus, PR experts and product advocates.",
+                                        "handle": "marketing-team",
+                                        "id": "S0615G0KT",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Marketing Team",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "U060RNRCZ",
+                                        "user_count": "0"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.list method",
@@ -20055,6 +23241,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.list method",
@@ -20179,6 +23371,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroup": {
+                                    "auto_type": null,
+                                    "created_by": "U060R4BJ4",
+                                    "date_create": 1447096577,
+                                    "date_delete": 0,
+                                    "date_update": 1447102109,
+                                    "deleted_by": null,
+                                    "description": "Marketing gurus, PR experts and product advocates.",
+                                    "handle": "marketing-team",
+                                    "id": "S0616NG6M",
+                                    "is_external": false,
+                                    "is_usergroup": true,
+                                    "name": "Marketing Team",
+                                    "prefs": {
+                                        "channels": [],
+                                        "groups": []
+                                    },
+                                    "team_id": "T060R4BHN",
+                                    "updated_by": "U060R4BJ4",
+                                    "user_count": 1,
+                                    "users": [
+                                        "U060R4BJ4",
+                                        "U060RNRCZ"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.update method",
@@ -20200,6 +23422,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.update method",
@@ -20300,6 +23528,15 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": [
+                                    "U060R4BJ4",
+                                    "W123A4BC5"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.users.list method",
@@ -20324,6 +23561,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.users.list method",
@@ -20432,6 +23675,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroup": {
+                                    "auto_type": null,
+                                    "created_by": "U060R4BJ4",
+                                    "date_create": 1447096577,
+                                    "date_delete": 0,
+                                    "date_update": 1447102109,
+                                    "deleted_by": null,
+                                    "description": "Marketing gurus, PR experts and product advocates.",
+                                    "handle": "marketing-team",
+                                    "id": "S0616NG6M",
+                                    "is_external": false,
+                                    "is_usergroup": true,
+                                    "name": "Marketing Team",
+                                    "prefs": {
+                                        "channels": [],
+                                        "groups": []
+                                    },
+                                    "team_id": "T060R4BHN",
+                                    "updated_by": "U060R4BJ4",
+                                    "user_count": 1,
+                                    "users": [
+                                        "U060R4BJ4",
+                                        "U060RNRCZ"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.users.update method",
@@ -20453,6 +23726,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.users.update method",
@@ -20570,6 +23849,78 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response with only public channels. Note how `num_members` and `is_member` are not returned like typical `conversations` objects.",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    },
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U061F7AUR",
+                                        "id": "C061EG9T2",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": false,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "random",
+                                        "name_normalized": "random",
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Non-work banter and water cooler conversation"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.conversations method. Returned conversation objects do not include `num_members` or `is_member`",
@@ -20607,6 +23958,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.conversations method",
@@ -20696,6 +24053,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.deletePhoto method",
@@ -20713,6 +24075,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.deletePhoto method",
@@ -20802,6 +24170,12 @@
                 "responses": {
                     "200": {
                         "description": "When requesting information for a different user, this method just returns the current presence (either `active` or `away`).",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "presence": "active"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Generated from users.getPresence with shasum e7251aec575d8863f9e0eb38663ae9dc26655f65",
@@ -20838,6 +24212,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -20897,6 +24277,18 @@
                 "responses": {
                     "200": {
                         "description": "You will receive at a minimum the following information:",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "id": "T0G9PQBBK"
+                                },
+                                "user": {
+                                    "id": "U0G9QF9C6",
+                                    "name": "Sonny Whether"
+                                }
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from users.identity method",
                             "items": [
@@ -21160,6 +24552,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "account_inactive",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.identity method",
@@ -21255,6 +24653,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "user": {
+                                    "color": "9f69e7",
+                                    "deleted": false,
+                                    "has_2fa": false,
+                                    "id": "W012A3CDE",
+                                    "is_admin": true,
+                                    "is_app_user": false,
+                                    "is_bot": false,
+                                    "is_owner": false,
+                                    "is_primary_owner": false,
+                                    "is_restricted": false,
+                                    "is_ultra_restricted": false,
+                                    "name": "spengler",
+                                    "profile": {
+                                        "avatar_hash": "ge3b51ca72de",
+                                        "display_name": "spengler",
+                                        "display_name_normalized": "spengler",
+                                        "email": "spengler@ghostbusters.example.com",
+                                        "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "real_name": "Egon Spengler",
+                                        "real_name_normalized": "Egon Spengler",
+                                        "status_emoji": ":books:",
+                                        "status_text": "Print is dead",
+                                        "team": "T012AB3C4"
+                                    },
+                                    "real_name": "Egon Spengler",
+                                    "team_id": "T012AB3C4",
+                                    "tz": "America/Los_Angeles",
+                                    "tz_label": "Pacific Daylight Time",
+                                    "tz_offset": -25200,
+                                    "updated": 1502138686
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.info method",
@@ -21276,6 +24717,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.info method",
@@ -21372,6 +24819,94 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "cache_ts": 1498777272,
+                                "members": [
+                                    {
+                                        "color": "9f69e7",
+                                        "deleted": false,
+                                        "has_2fa": false,
+                                        "id": "W012A3CDE",
+                                        "is_admin": true,
+                                        "is_app_user": false,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false,
+                                        "name": "spengler",
+                                        "profile": {
+                                            "avatar_hash": "ge3b51ca72de",
+                                            "display_name": "spengler",
+                                            "display_name_normalized": "spengler",
+                                            "email": "spengler@ghostbusters.example.com",
+                                            "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "real_name": "Egon Spengler",
+                                            "real_name_normalized": "Egon Spengler",
+                                            "status_emoji": ":books:",
+                                            "status_text": "Print is dead",
+                                            "team": "T012AB3C4"
+                                        },
+                                        "real_name": "spengler",
+                                        "team_id": "T012AB3C4",
+                                        "tz": "America/Los_Angeles",
+                                        "tz_label": "Pacific Daylight Time",
+                                        "tz_offset": -25200,
+                                        "updated": 1502138686
+                                    },
+                                    {
+                                        "color": "9f69e7",
+                                        "deleted": false,
+                                        "has_2fa": false,
+                                        "id": "W07QCRPA4",
+                                        "is_admin": true,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false,
+                                        "name": "glinda",
+                                        "profile": {
+                                            "avatar_hash": "8fbdd10b41c6",
+                                            "display_name": "Glinda the Fairly Good",
+                                            "display_name_normalized": "Glinda the Fairly Good",
+                                            "email": "glenda@south.oz.coven",
+                                            "first_name": "Glinda",
+                                            "image_1024": "https://a.slack-edge.com...png",
+                                            "image_192": "https://a.slack-edge.com...png",
+                                            "image_24": "https://a.slack-edge.com...png",
+                                            "image_32": "https://a.slack-edge.com...png",
+                                            "image_48": "https://a.slack-edge.com...png",
+                                            "image_512": "https://a.slack-edge.com...png",
+                                            "image_72": "https://a.slack-edge.com...png",
+                                            "image_original": "https://a.slack-edge.com...png",
+                                            "last_name": "Southgood",
+                                            "phone": "",
+                                            "real_name": "Glinda Southgood",
+                                            "real_name_normalized": "Glinda Southgood",
+                                            "skype": "",
+                                            "title": "Glinda the Good"
+                                        },
+                                        "real_name": "Glinda Southgood",
+                                        "team_id": "T0G9PQBBK",
+                                        "tz": "America/Los_Angeles",
+                                        "tz_label": "Pacific Daylight Time",
+                                        "tz_offset": -25200,
+                                        "updated": 1480527098
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dXNlcjpVMEc5V0ZYTlo="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.list method",
@@ -21405,6 +24940,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.list method",
@@ -21494,6 +25035,48 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "user": {
+                                    "color": "9f69e7",
+                                    "deleted": false,
+                                    "has_2fa": false,
+                                    "id": "W012A3CDE",
+                                    "is_admin": true,
+                                    "is_app_user": false,
+                                    "is_bot": false,
+                                    "is_owner": false,
+                                    "is_primary_owner": false,
+                                    "is_restricted": false,
+                                    "is_ultra_restricted": false,
+                                    "name": "spengler",
+                                    "profile": {
+                                        "avatar_hash": "ge3b51ca72de",
+                                        "display_name": "spengler",
+                                        "display_name_normalized": "spengler",
+                                        "email": "spengler@ghostbusters.example.com",
+                                        "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "real_name": "Egon Spengler",
+                                        "real_name_normalized": "Egon Spengler",
+                                        "status_emoji": ":books:",
+                                        "status_text": "Print is dead",
+                                        "team": "T012AB3C4"
+                                    },
+                                    "real_name": "Egon Spengler",
+                                    "team_id": "T012AB3C4",
+                                    "tz": "America/Los_Angeles",
+                                    "tz_label": "Pacific Daylight Time",
+                                    "tz_offset": -25200,
+                                    "updated": 1502138686
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.lookupByEmail method",
@@ -21515,6 +25098,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "users_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.lookupByEmail method",
@@ -21609,6 +25198,30 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "avatar_hash": "ge3b51ca72de",
+                                    "display_name": "spengler",
+                                    "display_name_normalized": "spengler",
+                                    "email": "spengler@ghostbusters.example.com",
+                                    "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "real_name": "Egon Spengler",
+                                    "real_name_normalized": "Egon Spengler",
+                                    "status_emoji": ":books:",
+                                    "status_expiration": 0,
+                                    "status_text": "Print is dead",
+                                    "team": "T012AB3C4"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.profile.get method",
@@ -21630,6 +25243,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.profile.get method",
@@ -21740,6 +25359,29 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "avatar_hash": "ge3b51ca72de",
+                                    "display_name": "spengler",
+                                    "display_name_normalized": "spengler",
+                                    "email": "spengler@ghostbusters.example.com",
+                                    "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "real_name": "Egon Spengler",
+                                    "real_name_normalized": "Egon Spengler",
+                                    "status_emoji": ":books:",
+                                    "status_expiration": 0,
+                                    "status_text": "Print is dead",
+                                    "team": "T012AB3C4"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.profile.set method",
@@ -21769,6 +25411,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_profile",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.profile.set method",
@@ -21860,6 +25508,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setActive method",
@@ -21877,6 +25530,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setActive method",
@@ -21983,6 +25642,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setPhoto method",
@@ -22054,6 +25718,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setPhoto method",
@@ -22161,6 +25831,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setPresence method",
@@ -22178,6 +25853,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setPresence method",
@@ -22276,6 +25957,52 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the opened view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AA4928AQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "a_block_id",
+                                            "element": {
+                                                "action_id": "an_action_id",
+                                                "type": "plain_text_input"
+                                            },
+                                            "label": {
+                                                "emoji": true,
+                                                "text": "A simple label",
+                                                "type": "plain_text"
+                                            },
+                                            "optional": false,
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "bot_id": "BA13894H",
+                                    "callback_id": "identify_your_modals",
+                                    "clear_on_close": false,
+                                    "external_id": "",
+                                    "hash": "156772938.1827394",
+                                    "id": "VMHU10V25",
+                                    "notify_on_close": false,
+                                    "private_metadata": "Shh it is a secret",
+                                    "root_view_id": "VMHU10V25",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": {
+                                        "text": "Create",
+                                        "type": "plain_text"
+                                    },
+                                    "team_id": "T8N4K1JN",
+                                    "title": {
+                                        "text": "Quite a plain modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22293,6 +26020,17 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "invalid `trigger_id`"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22368,6 +26106,42 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the published view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AA4928AQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "2WGp9",
+                                            "text": {
+                                                "text": "A simple section with some sample sentence.",
+                                                "type": "mrkdwn",
+                                                "verbatim": false
+                                            },
+                                            "type": "section"
+                                        }
+                                    ],
+                                    "bot_id": "BA13894H",
+                                    "callback_id": "identify_your_home_tab",
+                                    "clear_on_close": false,
+                                    "close": null,
+                                    "external_id": "",
+                                    "hash": "156772938.1827394",
+                                    "id": "VMHU10V25",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "Shh it is a secret",
+                                    "root_view_id": "VMHU10V25",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": null,
+                                    "team_id": "T8N4K1JN",
+                                    "type": "home"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22385,6 +26159,17 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "invalid `user_id`"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22454,6 +26239,58 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the pushed view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AAD3351BQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "edit_details",
+                                            "element": {
+                                                "action_id": "detail_input",
+                                                "type": "plain_text_input"
+                                            },
+                                            "label": {
+                                                "text": "Edit details",
+                                                "type": "plain_text"
+                                            },
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "bot_id": "BADF7A34H",
+                                    "callback_id": "view_4",
+                                    "clear_on_close": true,
+                                    "close": {
+                                        "emoji": true,
+                                        "text": "Back",
+                                        "type": "plain_text"
+                                    },
+                                    "external_id": "",
+                                    "hash": "1569362015.55b5e41b",
+                                    "id": "VNM522E2U",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "",
+                                    "root_view_id": "VNN729E3U",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": {
+                                        "emoji": true,
+                                        "text": "Save",
+                                        "type": "plain_text"
+                                    },
+                                    "team_id": "T9M4RL1JM",
+                                    "title": {
+                                        "emoji": true,
+                                        "text": "Pushed Modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22471,6 +26308,17 @@
                     },
                     "default": {
                         "description": "Typical error response.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "missing required field: title"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22550,6 +26398,59 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the updated view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AAD3351BQ",
+                                    "blocks": [
+                                        {
+                                            "accessory": {
+                                                "action_id": "button_4",
+                                                "text": {
+                                                    "text": "Click me",
+                                                    "type": "plain_text"
+                                                },
+                                                "type": "button"
+                                            },
+                                            "block_id": "s_block",
+                                            "text": {
+                                                "emoji": true,
+                                                "text": "I am but an updated modal",
+                                                "type": "plain_text"
+                                            },
+                                            "type": "section"
+                                        }
+                                    ],
+                                    "bot_id": "BADF7A34H",
+                                    "callback_id": "view_2",
+                                    "clear_on_close": true,
+                                    "close": {
+                                        "emoji": true,
+                                        "text": "Close",
+                                        "type": "plain_text"
+                                    },
+                                    "external_id": "",
+                                    "hash": "1569262015.55b5e41b",
+                                    "id": "VNM522E2U",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "",
+                                    "root_view_id": "VNN729E3U",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": null,
+                                    "team_id": "T9M4RL1JM",
+                                    "title": {
+                                        "emoji": true,
+                                        "text": "Updated Modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22567,6 +26468,12 @@
                     },
                     "default": {
                         "description": "Typical error response.",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22635,6 +26542,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22652,6 +26564,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22721,6 +26639,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22738,6 +26661,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22824,6 +26753,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22841,6 +26775,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",

--- a/resources/slack-openapi-sorted.patch
+++ b/resources/slack-openapi-sorted.patch
@@ -1,5 +1,5 @@
---- resources/slack-openapi-sorted.json	2021-02-24 15:12:58.000000000 -0700
-+++ resources/slack-openapi-patched.json	2021-02-24 15:16:56.000000000 -0700
+--- resources/slack-openapi-sorted.json	2021-04-09 21:59:46.253984964 +0200
++++ resources/slack-openapi-patched.json	2021-04-09 22:26:06.155769056 +0200
 @@ -397,21 +397,24 @@
                      },
                      "type": "array"
@@ -493,7 +493,7 @@
                      },
                      "type": [
                          "array",
-@@ -2332,36 +2397,35 @@
+@@ -2332,21 +2397,20 @@
                      },
                      {
                          "in": "formData",
@@ -514,24 +514,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-                             "additionalProperties": true,
-                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
-                             "properties": {
-                                 "ok": {
--                                    "$ref": "#/definitions/defs_ok_true"
-+                                    "$ref": "#/definitions/defs_ok_false"
-                                 }
-                             },
-                             "required": [
-                                 "ok"
-                             ],
-                             "title": "Default success template",
-                             "type": "object"
-                         }
-                     },
-                     "default": {
-@@ -2426,21 +2490,20 @@
+                         "examples": {
+@@ -2437,21 +2501,20 @@
                      },
                      {
                          "in": "query",
@@ -552,8 +536,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -2515,21 +2578,20 @@
+                         "examples": {
+@@ -2582,21 +2645,20 @@
                      },
                      {
                          "in": "query",
@@ -574,8 +558,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -2605,21 +2667,20 @@
+                         "examples": {
+@@ -2738,21 +2800,20 @@
                      },
                      {
                          "in": "formData",
@@ -596,8 +580,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -2699,21 +2760,20 @@
+                         "examples": {
+@@ -2843,21 +2904,20 @@
                      },
                      {
                          "in": "query",
@@ -618,8 +602,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -2779,21 +2839,20 @@
+                         "examples": {
+@@ -2979,21 +3039,20 @@
                          "description": "The channel to archive.",
                          "in": "formData",
                          "name": "channel_id",
@@ -640,8 +624,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -2873,21 +2932,20 @@
+                         "examples": {
+@@ -3084,21 +3143,20 @@
                          "description": "The channel to convert to private.",
                          "in": "formData",
                          "name": "channel_id",
@@ -662,8 +646,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -2993,21 +3051,20 @@
+                         "examples": {
+@@ -3215,21 +3273,20 @@
                      {
                          "description": "The workspace to create the channel in. Note: this argument is required unless you set `org_wide=true`.",
                          "in": "formData",
@@ -684,8 +668,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3090,21 +3147,20 @@
+                         "examples": {
+@@ -3324,21 +3381,20 @@
                          "description": "The channel to delete.",
                          "in": "formData",
                          "name": "channel_id",
@@ -706,8 +690,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3190,21 +3246,20 @@
+                         "examples": {
+@@ -3435,21 +3491,20 @@
                      {
                          "description": "The team to be removed from the channel. Currently only a single team id can be specified.",
                          "in": "formData",
@@ -728,8 +712,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3305,21 +3360,20 @@
+                         "examples": {
+@@ -3561,21 +3616,20 @@
                      {
                          "description": "A comma-separated list of the workspaces to which the channels you would like returned belong.",
                          "in": "query",
@@ -750,8 +734,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3385,21 +3439,20 @@
+                         "examples": {
+@@ -3660,21 +3714,20 @@
                          "description": "The channel to get preferences for.",
                          "in": "query",
                          "name": "channel_id",
@@ -772,8 +756,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3530,21 +3583,20 @@
+                         "examples": {
+@@ -3816,21 +3869,20 @@
                      {
                          "description": "The maximum number of items to return. Must be between 1 - 1000 both inclusive.",
                          "in": "query",
@@ -794,8 +778,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3643,21 +3695,20 @@
+                         "examples": {
+@@ -3944,21 +3996,20 @@
                          "description": "The channel that the users will be invited to.",
                          "in": "formData",
                          "name": "channel_id",
@@ -817,7 +801,7 @@
                          "type": "string"
                      }
                  ],
-@@ -3749,21 +3800,20 @@
+@@ -4061,21 +4112,20 @@
                      {
                          "in": "formData",
                          "name": "name",
@@ -838,8 +822,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3854,21 +3904,20 @@
+                         "examples": {
+@@ -4177,21 +4227,20 @@
                      {
                          "description": "The workspace where the channel exists. This argument is required for channels only tied to one workspace, and optional for channels that are shared across an organization.",
                          "in": "formData",
@@ -860,8 +844,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -3938,21 +3987,20 @@
+                         "examples": {
+@@ -4272,21 +4321,20 @@
                      {
                          "description": "The workspace where the channel exists. This argument is required for channels only tied to one workspace, and optional for channels that are shared across an organization.",
                          "in": "query",
@@ -882,8 +866,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4031,21 +4079,20 @@
+                         "examples": {
+@@ -4379,21 +4427,20 @@
                          "description": "The workspace where the channel exists. This argument is required for channels only tied to one workspace, and optional for channels that are shared across an organization.",
                          "in": "formData",
                          "name": "team_id",
@@ -904,8 +888,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4146,21 +4193,20 @@
+                         "examples": {
+@@ -4505,21 +4552,20 @@
                      {
                          "description": "Comma separated string of team IDs, signifying the workspaces to search through.",
                          "in": "query",
@@ -926,8 +910,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4256,21 +4302,20 @@
+                         "examples": {
+@@ -4664,21 +4710,20 @@
                          "description": "The prefs for this channel in a stringified JSON format.",
                          "in": "formData",
                          "name": "prefs",
@@ -948,8 +932,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4368,21 +4413,20 @@
+                         "examples": {
+@@ -4787,21 +4832,20 @@
                      {
                          "description": "The workspace to which the channel belongs. Omit this argument if the channel is a cross-workspace shared channel.",
                          "in": "formData",
@@ -970,8 +954,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4448,21 +4492,20 @@
+                         "examples": {
+@@ -4878,21 +4922,20 @@
                          "description": "The channel to unarchive.",
                          "in": "formData",
                          "name": "channel_id",
@@ -992,8 +976,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4541,21 +4584,20 @@
+                         "examples": {
+@@ -4982,21 +5025,20 @@
                          "description": "The name of the emoji to be removed. Colons (`:myemoji:`) around the value are not required, although they may be included.",
                          "in": "formData",
                          "name": "name",
@@ -1015,7 +999,7 @@
                          "type": "string"
                      }
                  ],
-@@ -4634,21 +4676,20 @@
+@@ -5086,21 +5128,20 @@
                          "description": "The name of the emoji to be aliased. Colons (`:myemoji:`) around the value are not required, although they may be included.",
                          "in": "formData",
                          "name": "name",
@@ -1036,8 +1020,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4718,21 +4759,20 @@
+                         "examples": {
+@@ -5181,21 +5222,20 @@
                      {
                          "description": "The maximum number of items to return. Must be between 1 - 1000 both inclusive.",
                          "in": "query",
@@ -1058,8 +1042,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4797,21 +4837,20 @@
+                         "examples": {
+@@ -5303,21 +5343,20 @@
                          "description": "The name of the emoji to be removed. Colons (`:myemoji:`) around the value are not required, although they may be included.",
                          "in": "formData",
                          "name": "name",
@@ -1080,8 +1064,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4883,21 +4922,20 @@
+                         "examples": {
+@@ -5400,21 +5439,20 @@
                          "description": "The new name of the emoji.",
                          "in": "formData",
                          "name": "new_name",
@@ -1102,8 +1086,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -4969,21 +5007,20 @@
+                         "examples": {
+@@ -5497,21 +5535,20 @@
                      {
                          "description": "ID for the workspace where the invite request was made.",
                          "in": "formData",
@@ -1124,8 +1108,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5060,21 +5097,20 @@
+                         "examples": {
+@@ -5599,21 +5636,20 @@
                      {
                          "description": "ID for the workspace where the invite requests were made.",
                          "in": "query",
@@ -1146,8 +1130,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5151,21 +5187,20 @@
+                         "examples": {
+@@ -5701,21 +5737,20 @@
                      {
                          "description": "ID for the workspace where the invite requests were made.",
                          "in": "query",
@@ -1168,8 +1152,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5237,21 +5272,20 @@
+                         "examples": {
+@@ -5798,21 +5833,20 @@
                      {
                          "description": "ID for the workspace where the invite request was made.",
                          "in": "formData",
@@ -1190,8 +1174,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5328,21 +5362,20 @@
+                         "examples": {
+@@ -5900,21 +5934,20 @@
                      {
                          "description": "ID for the workspace where the invite requests were made.",
                          "in": "query",
@@ -1212,8 +1196,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5418,21 +5451,20 @@
+                         "examples": {
+@@ -6001,21 +6034,20 @@
                      {
                          "in": "query",
                          "name": "team_id",
@@ -1234,8 +1218,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5517,21 +5549,20 @@
+                         "examples": {
+@@ -6114,21 +6146,20 @@
                          "description": "Team name (for example, Slack Softball Team).",
                          "in": "formData",
                          "name": "team_name",
@@ -1256,8 +1240,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5602,21 +5633,20 @@
+                         "examples": {
+@@ -6211,21 +6242,20 @@
                      {
                          "description": "The maximum number of items to return. Must be between 1 - 100 both inclusive.",
                          "in": "query",
@@ -1278,8 +1262,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5692,21 +5722,20 @@
+                         "examples": {
+@@ -6324,21 +6354,20 @@
                      {
                          "in": "query",
                          "name": "team_id",
@@ -1300,8 +1284,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5771,21 +5800,20 @@
+                         "examples": {
+@@ -6417,21 +6446,20 @@
                      {
                          "in": "query",
                          "name": "team_id",
@@ -1322,8 +1306,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5857,21 +5885,20 @@
+                         "examples": {
+@@ -6524,21 +6552,20 @@
                          "description": "ID for the workspace to set the default channel for.",
                          "in": "formData",
                          "name": "team_id",
@@ -1344,8 +1328,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -5944,21 +5971,20 @@
+                         "examples": {
+@@ -6622,21 +6649,20 @@
                          "description": "ID for the workspace to set the description for.",
                          "in": "formData",
                          "name": "team_id",
@@ -1366,8 +1350,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -6031,21 +6057,20 @@
+                         "examples": {
+@@ -6720,21 +6746,20 @@
                          "description": "The ID of the workspace to set discoverability on.",
                          "in": "formData",
                          "name": "team_id",
@@ -1388,8 +1372,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -6117,21 +6142,20 @@
+                         "examples": {
+@@ -6817,21 +6842,20 @@
                          "description": "ID for the workspace to set the icon for.",
                          "in": "formData",
                          "name": "team_id",
@@ -1410,8 +1394,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -6204,21 +6228,20 @@
+                         "examples": {
+@@ -6915,21 +6939,20 @@
                          "description": "ID for the workspace to set the name for.",
                          "in": "formData",
                          "name": "team_id",
@@ -1432,8 +1416,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -6290,21 +6313,20 @@
+                         "examples": {
+@@ -7012,21 +7035,20 @@
                      {
                          "description": "The workspace to add default channels in.",
                          "in": "formData",
@@ -1455,7 +1439,7 @@
                          "type": "string"
                      }
                  ],
-@@ -6383,21 +6405,20 @@
+@@ -7116,21 +7138,20 @@
                          "description": "A comma separated list of encoded team (workspace) IDs. Each workspace *MUST* belong to the organization associated with the token.",
                          "in": "formData",
                          "name": "team_ids",
@@ -1477,7 +1461,7 @@
                          "type": "string"
                      }
                  ],
-@@ -6475,21 +6496,20 @@
+@@ -7219,21 +7240,20 @@
                      {
                          "description": "ID of the the workspace.",
                          "in": "query",
@@ -1499,7 +1483,7 @@
                          "type": "string"
                      }
                  ],
-@@ -6562,21 +6582,20 @@
+@@ -7342,21 +7362,20 @@
                          "description": "Comma-separated string of channel IDs",
                          "in": "formData",
                          "name": "channel_ids",
@@ -1521,7 +1505,7 @@
                          "type": "string"
                      }
                  ],
-@@ -6667,21 +6686,20 @@
+@@ -7458,21 +7477,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1543,7 +1527,7 @@
                          "type": "string"
                      }
                  ],
-@@ -6804,21 +6822,20 @@
+@@ -7606,21 +7624,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1564,8 +1548,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -6896,21 +6913,20 @@
+                         "examples": {
+@@ -7709,21 +7726,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "query",
                          "name": "team_id",
@@ -1586,8 +1570,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -6976,21 +6992,20 @@
+                         "examples": {
+@@ -7812,21 +7828,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1609,7 +1593,7 @@
                          "type": "string"
                      }
                  ],
-@@ -7069,21 +7084,20 @@
+@@ -7916,21 +7931,20 @@
                          "description": "ID of the team that the session belongs to",
                          "in": "formData",
                          "name": "team_id",
@@ -1630,8 +1614,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -7148,21 +7162,20 @@
+                         "examples": {
+@@ -8006,21 +8020,20 @@
                      {
                          "description": "Only expire mobile sessions (default: false)",
                          "in": "formData",
@@ -1653,7 +1637,7 @@
                          "type": "string"
                      },
                      {
-@@ -7241,21 +7254,20 @@
+@@ -8110,21 +8123,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1675,7 +1659,7 @@
                          "type": "string"
                      }
                  ],
-@@ -7335,21 +7347,20 @@
+@@ -8215,21 +8227,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1697,7 +1681,7 @@
                          "type": "string"
                      }
                  ],
-@@ -7422,21 +7433,20 @@
+@@ -8313,21 +8324,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1719,7 +1703,7 @@
                          "type": "string"
                      }
                  ],
-@@ -7509,21 +7519,20 @@
+@@ -8411,21 +8421,20 @@
                          "description": "The ID (`T1234`) of the workspace.",
                          "in": "formData",
                          "name": "team_id",
@@ -1741,11 +1725,11 @@
                          "type": "string"
                      }
                  ],
-@@ -7610,39 +7619,45 @@
-                 ],
-                 "responses": {
-                     "200": {
-                         "description": "Standard success response",
+@@ -8528,20 +8537,23 @@
+                             "application/json": {
+                                 "ok": true
+                             }
+                         },
                          "schema": {
                              "additionalProperties": {
                                  "type": "object"
@@ -1765,9 +1749,11 @@
                              "title": "api.test success schema",
                              "type": "object"
                          }
-                     },
-                     "default": {
-                         "description": "Artificial error response",
+@@ -8556,20 +8568,23 @@
+                                 "error": "my_error",
+                                 "ok": false
+                             }
+                         },
                          "schema": {
                              "additionalProperties": {
                                  "type": "object"
@@ -1787,7 +1773,7 @@
                              "required": [
                                  "error",
                                  "ok"
-@@ -7690,21 +7705,20 @@
+@@ -8617,21 +8632,20 @@
                      },
                      {
                          "in": "query",
@@ -1808,8 +1794,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -7953,21 +7967,20 @@
+                         "examples": {
+@@ -8959,21 +8973,20 @@
                          "description": "A comma separated list of scopes to request for",
                          "in": "query",
                          "name": "scopes",
@@ -1831,7 +1817,7 @@
                          "type": "string"
                      }
                  ],
-@@ -8077,21 +8090,20 @@
+@@ -9094,21 +9107,20 @@
                      {
                          "description": "The maximum number of items to return.",
                          "in": "query",
@@ -1852,8 +1838,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical successful paginated response",
-                         "schema": {
-@@ -8220,21 +8232,20 @@
+                         "examples": {
+@@ -9265,21 +9277,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/apps.permissions.scopes.list"
@@ -1874,8 +1860,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical successful paginated response",
-                         "schema": {
-@@ -8361,21 +8372,20 @@
+                         "examples": {
+@@ -9441,21 +9452,20 @@
                      {
                          "description": "The maximum number of items to return.",
                          "in": "query",
@@ -1896,8 +1882,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical successful paginated response",
-                         "schema": {
-@@ -8440,21 +8450,20 @@
+                         "examples": {
+@@ -9549,21 +9559,20 @@
                          "description": "A comma separated list of user scopes to request for",
                          "in": "query",
                          "name": "scopes",
@@ -1919,7 +1905,7 @@
                          "type": "string"
                      },
                      {
-@@ -8646,21 +8655,20 @@
+@@ -9777,21 +9786,20 @@
                      {
                          "description": "Setting this parameter to `1` triggers a _testing mode_ where the specified token will not actually be revoked.",
                          "in": "query",
@@ -1940,8 +1926,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -8750,21 +8758,20 @@
+                         "examples": {
+@@ -9893,21 +9901,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/auth.test"
@@ -1962,8 +1948,8 @@
                  "responses": {
                      "200": {
                          "description": "Standard success response when used with a user token",
-                         "schema": {
-@@ -8877,21 +8884,20 @@
+                         "examples": {
+@@ -10036,21 +10043,20 @@
                      {
                          "description": "Bot user to get info on",
                          "in": "query",
@@ -1984,8 +1970,8 @@
                  "responses": {
                      "200": {
                          "description": "When successful, returns bot info by bot ID.",
-                         "schema": {
-@@ -9078,21 +9084,20 @@
+                         "examples": {
+@@ -10261,21 +10267,20 @@
                      {
                          "description": "The name of the Call.",
                          "in": "formData",
@@ -2007,7 +1993,7 @@
                      }
                  ],
                  "produces": [
-@@ -9169,21 +9174,20 @@
+@@ -10363,21 +10368,20 @@
                          "description": "`id` returned when registering the call using the [`calls.add`](/methods/calls.add) method.",
                          "in": "formData",
                          "name": "id",
@@ -2028,8 +2014,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -9248,21 +9252,20 @@
+                         "examples": {
+@@ -10453,21 +10457,20 @@
                          "description": "`id` of the Call returned by the [`calls.add`](/methods/calls.add) method.",
                          "in": "query",
                          "name": "id",
@@ -2050,8 +2036,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -9327,21 +9330,20 @@
+                         "examples": {
+@@ -10543,21 +10546,20 @@
                          "description": "`id` returned by the [`calls.add`](/methods/calls.add) method.",
                          "in": "formData",
                          "name": "id",
@@ -2073,7 +2059,7 @@
                          "type": "string"
                      }
                  ],
-@@ -9414,21 +9416,20 @@
+@@ -10641,21 +10643,20 @@
                          "description": "`id` returned by the [`calls.add`](/methods/calls.add) method.",
                          "in": "formData",
                          "name": "id",
@@ -2095,7 +2081,7 @@
                          "type": "string"
                      }
                  ],
-@@ -9519,21 +9520,20 @@
+@@ -10757,21 +10758,20 @@
                      {
                          "description": "The name of the Call.",
                          "in": "formData",
@@ -2116,8 +2102,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -9609,21 +9609,21 @@
+                         "examples": {
+@@ -10858,21 +10858,21 @@
                      {
                          "description": "Authentication token. Requires scope: `chat:write`",
                          "in": "header",
@@ -2138,9 +2124,9 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-                             "additionalProperties": false,
-@@ -9740,21 +9740,20 @@
+                         "examples": {
+                             "application/json": {
+@@ -11002,21 +11002,20 @@
                          "description": "`scheduled_message_id` returned from call to chat.scheduleMessage",
                          "in": "formData",
                          "name": "scheduled_message_id",
@@ -2161,8 +2147,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -9859,21 +9858,20 @@
+                         "examples": {
+@@ -11132,21 +11131,20 @@
                          "description": "A message's `ts` value, uniquely identifying it within a channel",
                          "in": "query",
                          "name": "message_ts",
@@ -2183,8 +2169,8 @@
                  "responses": {
                      "200": {
                          "description": "Standard success response",
-                         "schema": {
-@@ -10155,21 +10153,20 @@
+                         "examples": {
+@@ -11454,21 +11452,20 @@
                      {
                          "description": "Provide another message's `ts` value to post this message in a thread. Avoid using a reply's `ts` value; use its parent's value instead. Ephemeral messages in threads are only shown if there is already an active thread.",
                          "in": "formData",
@@ -2206,7 +2192,7 @@
                          "type": "string"
                      },
                      {
-@@ -10280,21 +10277,21 @@
+@@ -11591,21 +11588,21 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/chat.postMessage"
@@ -2229,7 +2215,7 @@
                      {
                          "description": "A JSON-based array of structured blocks, presented as a URL-encoded string.",
                          "in": "formData",
-@@ -10353,21 +10350,20 @@
+@@ -11664,21 +11661,20 @@
                      {
                          "description": "Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.",
                          "in": "formData",
@@ -2251,7 +2237,7 @@
                      },
                      {
                          "description": "Pass false to disable unfurling of media content.",
-@@ -10518,39 +10514,39 @@
+@@ -11857,39 +11853,39 @@
                      {
                          "description": "Change how messages are treated. Defaults to `none`. See [chat.postMessage](chat.postMessage#formatting).",
                          "in": "formData",
@@ -2293,7 +2279,7 @@
                      {
                          "description": "Pass true to enable unfurling of primarily text-based content.",
                          "in": "formData",
-@@ -10573,26 +10569,46 @@
+@@ -11934,26 +11930,46 @@
                          "schema": {
                              "additionalProperties": false,
                              "description": "Schema for successful response of chat.scheduleMessage method",
@@ -2340,7 +2326,7 @@
                                              "type": "string"
                                          },
                                          "user": {
-@@ -10608,22 +10624,24 @@
+@@ -11969,22 +11985,24 @@
                                          "text",
                                          "type",
                                          "user"
@@ -2367,7 +2353,7 @@
                              "required": [
                                  "channel",
                                  "message",
-@@ -10732,33 +10750,33 @@
+@@ -12099,33 +12117,33 @@
                      {
                          "description": "For pagination purposes, this is the `cursor` value returned from a previous call to `chat.scheduledmessages.list` indicating where you want to start this call from.",
                          "in": "query",
@@ -2403,7 +2389,7 @@
                  ],
                  "produces": [
                      "application/json"
-@@ -10791,25 +10809,27 @@
+@@ -12175,25 +12193,27 @@
                                          "properties": {
                                              "channel_id": {
                                                  "$ref": "#/definitions/defs_channel_id"
@@ -2434,7 +2420,7 @@
                                              "date_created",
                                              "id",
                                              "post_at"
-@@ -10907,21 +10927,20 @@
+@@ -12297,21 +12317,20 @@
                          "description": "Channel ID of the message",
                          "in": "formData",
                          "name": "channel",
@@ -2456,7 +2442,7 @@
                          "type": "string"
                      },
                      {
-@@ -11043,21 +11062,21 @@
+@@ -12444,21 +12463,21 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/chat.update"
@@ -2479,7 +2465,7 @@
                      {
                          "description": "A JSON-based array of [structured blocks](/block-kit/building), presented as a URL-encoded string. If you don't include this field, the message's previous `blocks` will be retained. To remove previous `blocks`, include an empty array for this field.",
                          "in": "formData",
-@@ -11086,21 +11105,20 @@
+@@ -12487,21 +12506,20 @@
                      {
                          "description": "New text for the message, using the [default formatting rules](/reference/surfaces/formatting). It's not required when presenting `blocks` or `attachments`.",
                          "in": "formData",
@@ -2501,7 +2487,7 @@
                          "type": "string"
                      }
                  ],
-@@ -11629,33 +11647,33 @@
+@@ -13118,33 +13136,33 @@
                      {
                          "description": "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
                          "in": "query",
@@ -2537,7 +2523,7 @@
                  ],
                  "produces": [
                      "application/json"
-@@ -11689,20 +11707,32 @@
+@@ -13202,20 +13220,32 @@
                                      },
                                      "minItems": 1,
                                      "type": "array",
@@ -2570,7 +2556,7 @@
                                  "ok",
                                  "pin_count"
                              ],
-@@ -12655,21 +12685,21 @@
+@@ -14429,21 +14459,21 @@
                      {
                          "description": "Authentication token. Requires scope: `conversations:write`",
                          "in": "header",
@@ -2591,9 +2577,9 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-                             "additionalProperties": false,
-@@ -13228,45 +13258,45 @@
+                         "examples": {
+                             "application/json": {
+@@ -15097,45 +15127,45 @@
                      {
                          "description": "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
                          "in": "query",
@@ -2640,9 +2626,9 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-                             "additionalProperties": false,
-@@ -13391,20 +13421,32 @@
+                         "examples": {
+                             "application/json": {
+@@ -15306,20 +15336,32 @@
                                                      "user"
                                                  ],
                                                  "type": "object"
@@ -2675,7 +2661,7 @@
                              "type": "object"
                          }
                      },
-@@ -13864,21 +13906,20 @@
+@@ -15818,21 +15860,20 @@
                          "description": "The dialog definition. This must be a JSON-encoded string.",
                          "in": "query",
                          "name": "dialog",
@@ -2697,7 +2683,7 @@
                          "type": "string"
                      }
                  ],
-@@ -13980,21 +14021,20 @@
+@@ -15945,21 +15986,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/dnd.endDnd"
@@ -2718,8 +2704,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -14082,21 +14122,20 @@
+                         "examples": {
+@@ -16058,21 +16098,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/dnd.endSnooze"
@@ -2740,8 +2726,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -14333,21 +14372,20 @@
+                         "examples": {
+@@ -16331,21 +16370,20 @@
                          "description": "Number of minutes, from now, to snooze until.",
                          "in": "formData",
                          "name": "num_minutes",
@@ -2762,31 +2748,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -14481,21 +14519,21 @@
-                             "required": [
-                                 "ok"
-                             ],
-                             "title": "Default success template",
-                             "type": "object"
-                         }
-                     },
-                     "default": {
-                         "description": "Typical error response",
-                         "schema": {
--                            "additionalProperties": true,
-+                            "additionalProperties": false,
-                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
-                             "properties": {
-                                 "ok": {
-                                     "$ref": "#/definitions/defs_ok_false"
-                                 }
-                             },
-                             "required": [
-                                 "ok"
-                             ],
-                             "title": "Default error template",
-@@ -14524,21 +14562,20 @@
+                         "examples": {
+@@ -16556,21 +16594,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/emoji.list"
@@ -2807,8 +2770,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -14984,27 +15021,27 @@
+                         "examples": {
+@@ -17126,27 +17163,27 @@
                      {
                          "description": "Authentication token. Requires scope: `files:read`",
                          "in": "query",
@@ -2838,7 +2801,7 @@
                      {
                          "description": "Filter files created by a single user.",
                          "in": "query",
-@@ -15327,27 +15364,27 @@
+@@ -17594,27 +17631,27 @@
                      {
                          "description": "Authentication token. Requires scope: `remote_files:read`",
                          "in": "query",
@@ -2866,9 +2829,9 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-                             "additionalProperties": true,
-@@ -15901,21 +15938,21 @@
+                         "examples": {
+                             "application/json": {
+@@ -18234,21 +18271,21 @@
                      }
                  ],
                  "tags": [
@@ -2891,7 +2854,7 @@
                  "parameters": [
                      {
                          "description": "Comma-separated list of channel names or IDs where the file will be shared.",
-@@ -15926,21 +15963,21 @@
+@@ -18259,21 +18296,21 @@
                      {
                          "description": "File contents via a POST variable. If omitting this parameter, you must provide a `file`.",
                          "in": "formData",
@@ -2914,7 +2877,7 @@
                      {
                          "description": "A [file type](/types/file#file_types) identifier.",
                          "in": "formData",
-@@ -15950,21 +15987,21 @@
+@@ -18283,21 +18320,21 @@
                      {
                          "description": "The message text introducing the file in specified `channels`.",
                          "in": "formData",
@@ -2937,7 +2900,7 @@
                      {
                          "description": "Authentication token. Requires scope: `files:write:user`",
                          "in": "formData",
-@@ -16079,21 +16116,20 @@
+@@ -18478,21 +18515,20 @@
                      {
                          "description": "Specify `true` to convert `W` global user IDs to workspace-specific `U` IDs. Defaults to `false`.",
                          "in": "query",
@@ -2959,7 +2922,7 @@
                          "type": "string"
                      }
                  ],
-@@ -16487,34 +16523,32 @@
+@@ -18984,34 +19020,32 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/pins.add"
@@ -2993,8 +2956,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -16604,28 +16638,26 @@
+                         "examples": {
+@@ -19112,28 +19146,26 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/pins.list"
@@ -3022,8 +2985,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -16796,21 +16828,20 @@
+                         "examples": {
+@@ -19349,21 +19381,20 @@
                      {
                          "description": "Timestamp of the message to un-pin.",
                          "in": "formData",
@@ -3044,8 +3007,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -16921,21 +16952,20 @@
+                         "examples": {
+@@ -19485,21 +19516,20 @@
                          "description": "Timestamp of the message to add reaction to.",
                          "in": "formData",
                          "name": "timestamp",
@@ -3066,8 +3029,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -17054,33 +17084,32 @@
+                         "examples": {
+@@ -19629,21 +19659,20 @@
                      {
                          "description": "Timestamp of the message to get reactions for.",
                          "in": "query",
@@ -3088,6 +3051,16 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
+                         "examples": {
+@@ -19670,21 +19699,21 @@
+                                     "timestamp": 1507850315,
+                                     "title": "computer.gif",
+                                     "user": "U2U85N1RV"
+                                 },
+                                 "ok": true,
+                                 "type": "file"
+                             }
+                         },
                          "schema": {
                              "description": "Schema for successful response from reactions.get method",
 -                            "items": [
@@ -3102,31 +3075,7 @@
                                              "$ref": "#/definitions/objs_message"
                                          },
                                          "ok": {
-@@ -17142,22 +17171,21 @@
-                                         }
-                                     },
-                                     "required": [
-                                         "comment",
-                                         "file",
-                                         "ok",
-                                         "type"
-                                     ]
-                                 }
-                             ],
--                            "title": "reactions.get success schema",
--                            "type": "object"
-+                            "title": "reactions.get success schema"
-                         }
-                     },
-                     "default": {
-                         "description": "Typical error response",
-                         "schema": {
-                             "additionalProperties": false,
-                             "description": "Schema for error response from reactions.get method",
-                             "properties": {
-                                 "callstack": {
-                                     "description": "Note: PHP callstack is only visible in dev/qa",
-@@ -17249,21 +17277,20 @@
+@@ -19859,21 +19888,20 @@
                      },
                      {
                          "in": "query",
@@ -3148,7 +3097,7 @@
                      }
                  ],
                  "produces": [
-@@ -17464,21 +17491,20 @@
+@@ -20173,21 +20201,20 @@
                      {
                          "description": "Timestamp of the message to remove reaction from.",
                          "in": "formData",
@@ -3169,8 +3118,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -17583,21 +17609,20 @@
+                         "examples": {
+@@ -20303,21 +20330,20 @@
                          "description": "When this reminder should happen: the Unix timestamp (up to five years from now), the number of seconds until the reminder (if within 24 hours), or a natural language description (Ex. \"in 15 minutes,\" or \"every Thursday\")",
                          "in": "formData",
                          "name": "time",
@@ -3192,7 +3141,7 @@
                      }
                  ],
                  "produces": [
-@@ -18143,21 +18168,20 @@
+@@ -20918,21 +20944,20 @@
                      {
                          "description": "Only deliver presence events when requested by subscription. See [presence subscriptions](/docs/presence-and-status#subscriptions).",
                          "in": "query",
@@ -3213,8 +3162,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -18320,21 +18344,20 @@
+                         "examples": {
+@@ -21116,21 +21141,20 @@
                      {
                          "description": "Change sort direction to ascending (`asc`) or descending (`desc`).",
                          "in": "query",
@@ -3235,8 +3184,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -18416,21 +18439,20 @@
+                         "examples": {
+@@ -21285,21 +21309,20 @@
                      {
                          "description": "Timestamp of the message to add star to.",
                          "in": "formData",
@@ -3257,8 +3206,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -18825,21 +18847,20 @@
+                         "examples": {
+@@ -21716,21 +21739,20 @@
                      {
                          "description": "Timestamp of the message to remove star from.",
                          "in": "formData",
@@ -3279,8 +3228,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -18947,21 +18968,20 @@
+                         "examples": {
+@@ -21849,21 +21871,20 @@
                      },
                      {
                          "in": "query",
@@ -3301,8 +3250,8 @@
                  "responses": {
                      "200": {
                          "description": "This response demonstrates pagination and two access log entries.",
-                         "schema": {
-@@ -19119,21 +19139,20 @@
+                         "examples": {
+@@ -22064,21 +22085,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/team.billableInfo"
@@ -3324,7 +3273,7 @@
                      }
                  ],
                  "produces": [
-@@ -19202,21 +19221,20 @@
+@@ -22169,21 +22189,20 @@
                      {
                          "description": "Team to get info on, if omitted, will return information about the current team. Will only return team that the authenticated token is allowed to see through external shared channels",
                          "in": "query",
@@ -3345,8 +3294,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -19332,21 +19350,20 @@
+                         "examples": {
+@@ -22327,21 +22346,20 @@
                      {
                          "description": "Filter logs to this service. Defaults to all logs.",
                          "in": "query",
@@ -3368,7 +3317,7 @@
                      }
                  ],
                  "produces": [
-@@ -19496,21 +19513,20 @@
+@@ -22502,21 +22520,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/team.profile.get"
@@ -3390,7 +3339,7 @@
                      }
                  ],
                  "produces": [
-@@ -19649,21 +19665,20 @@
+@@ -22732,21 +22749,20 @@
                          "description": "A name for the User Group. Must be unique among User Groups.",
                          "in": "formData",
                          "name": "name",
@@ -3411,8 +3360,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -19762,21 +19777,20 @@
+                         "examples": {
+@@ -22856,21 +22872,20 @@
                      {
                          "description": "Include the number of users in the User Group.",
                          "in": "formData",
@@ -3434,7 +3383,7 @@
                          "type": "string"
                      }
                  ],
-@@ -19882,21 +19896,20 @@
+@@ -22987,21 +23002,20 @@
                      {
                          "description": "Include the number of users in the User Group.",
                          "in": "formData",
@@ -3456,7 +3405,7 @@
                          "type": "string"
                      }
                  ],
-@@ -20014,21 +20027,20 @@
+@@ -23130,21 +23144,20 @@
                      {
                          "description": "Include the list of users for each User Group.",
                          "in": "query",
@@ -3477,8 +3426,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -20155,21 +20167,20 @@
+                         "examples": {
+@@ -23347,21 +23360,20 @@
                      {
                          "description": "A name for the User Group. Must be unique among User Groups.",
                          "in": "formData",
@@ -3500,7 +3449,7 @@
                          "type": "string"
                      }
                  ],
-@@ -20276,25 +20287,24 @@
+@@ -23504,25 +23516,24 @@
                      {
                          "description": "Allow results that involve disabled User Groups.",
                          "in": "query",
@@ -3527,7 +3476,7 @@
                      "application/json"
                  ],
                  "responses": {
-@@ -20401,21 +20411,20 @@
+@@ -23644,21 +23655,20 @@
                      {
                          "description": "Include the number of users in the User Group.",
                          "in": "formData",
@@ -3549,7 +3498,7 @@
                          "type": "string"
                      },
                      {
-@@ -20679,21 +20688,20 @@
+@@ -24036,21 +24046,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/users.deletePhoto"
@@ -3570,8 +3519,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -20779,21 +20787,20 @@
+                         "examples": {
+@@ -24147,21 +24156,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/users.getPresence"
@@ -3593,7 +3542,7 @@
                      }
                  ],
                  "produces": [
-@@ -21232,21 +21239,20 @@
+@@ -24630,21 +24638,20 @@
                      {
                          "description": "Set this to `true` to receive the locale for this user. Defaults to `false`",
                          "in": "query",
@@ -3615,7 +3564,7 @@
                      }
                  ],
                  "produces": [
-@@ -21470,28 +21476,26 @@
+@@ -25011,28 +25018,26 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/users.lookupByEmail"
@@ -3643,8 +3592,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -21586,21 +21590,20 @@
+                         "examples": {
+@@ -25175,21 +25180,20 @@
                      {
                          "description": "Include labels for each ID in custom profile fields",
                          "in": "query",
@@ -3666,7 +3615,7 @@
                      }
                  ],
                  "produces": [
-@@ -21711,21 +21714,20 @@
+@@ -25330,21 +25334,20 @@
                      {
                          "description": "Collection of key:value pairs presented as a URL-encoded JSON hash. At most 50 fields may be set. Each field name is limited to 255 characters.",
                          "in": "formData",
@@ -3688,7 +3637,7 @@
                      },
                      {
                          "description": "Value to set a single key to. Usable only if `profile` is not passed.",
-@@ -21843,21 +21845,20 @@
+@@ -25491,21 +25494,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/users.setActive"
@@ -3709,8 +3658,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -21966,21 +21967,20 @@
+                         "examples": {
+@@ -25625,21 +25627,20 @@
                      {
                          "description": "File contents via `multipart/form-data`.",
                          "in": "formData",
@@ -3731,8 +3680,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -22144,21 +22144,20 @@
+                         "examples": {
+@@ -25814,21 +25815,20 @@
                          "description": "Either `auto` or `away`",
                          "in": "formData",
                          "name": "presence",
@@ -3753,8 +3702,8 @@
                  "responses": {
                      "200": {
                          "description": "Typical success response",
-                         "schema": {
-@@ -22245,21 +22244,20 @@
+                         "examples": {
+@@ -25926,21 +25926,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/views.open"
@@ -3776,7 +3725,7 @@
                          "type": "string"
                      },
                      {
-@@ -22337,21 +22335,20 @@
+@@ -26075,21 +26074,20 @@
                      {
                          "description": "A string that represents view state to protect against possible race conditions.",
                          "in": "query",
@@ -3798,7 +3747,7 @@
                          "type": "string"
                      },
                      {
-@@ -22423,21 +22420,20 @@
+@@ -26208,21 +26206,20 @@
                  "externalDocs": {
                      "description": "API method documentation",
                      "url": "https://api.slack.com/methods/views.push"
@@ -3820,7 +3769,7 @@
                          "type": "string"
                      },
                      {
-@@ -22521,21 +22517,20 @@
+@@ -26369,21 +26366,20 @@
                      {
                          "description": "A string that represents view state to protect against possible race conditions.",
                          "in": "query",
@@ -3842,7 +3791,7 @@
                      },
                      {
                          "description": "A unique identifier of the view to be updated. Either `view_id` or `external_id` is required.",
-@@ -22611,21 +22606,20 @@
+@@ -26518,21 +26514,20 @@
                      {
                          "description": "Key-value object of outputs from your step. Keys of this object reflect the configured `key` properties of your [`outputs`](/reference/workflows/workflow_step#output) array from your `workflow_step` object.",
                          "in": "query",
@@ -3864,7 +3813,7 @@
                          "type": "string"
                      }
                  ],
-@@ -22697,21 +22691,20 @@
+@@ -26615,21 +26610,20 @@
                          "description": "A JSON-based object with a `message` property that should contain a human readable error message.",
                          "in": "query",
                          "name": "error",
@@ -3886,7 +3835,7 @@
                          "type": "string"
                      }
                  ],
-@@ -22800,21 +22793,20 @@
+@@ -26729,21 +26723,20 @@
                      {
                          "description": "An optional field that can be used to override the step name that is shown in the Workflow Builder.",
                          "in": "query",

--- a/resources/slack-openapi.json
+++ b/resources/slack-openapi.json
@@ -2895,6 +2895,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -2912,6 +2917,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -2989,6 +3000,56 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "approved_apps": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://myteam.enterprise.slack.com/apps/A0W7UKG8E-my-test-app",
+                                            "app_homepage_url": "https://www.slack.com",
+                                            "description": "test app",
+                                            "help_url": "https://www.slack.com",
+                                            "icons": {
+                                                "image_1024": "https://3026743124446w96_2bd4ea1ad1f89a23c242_1024.png",
+                                                "image_128": "https://30267341249446w6_2bd4ea1ad1f89a23c242_128.png",
+                                                "image_192": "https://30267431249446w6_2bd4ea1ad1f89a23c242_192.png",
+                                                "image_32": "https://302674312496446w_2bd4ea1ad1f89a23c242_32.png",
+                                                "image_36": "https://302674312496446w_2bd4ea1ad1f89a23c242_36.png",
+                                                "image_48": "https://302674312496446w_2bd4ea1ad1f89a23c242_48.png",
+                                                "image_512": "https://30267431249446w6_2bd4ea1ad1f89a23c242_512.png",
+                                                "image_64": "https://302674312496446w_2bd4ea1ad1f89a23c242_64.png",
+                                                "image_72": "https://302674312496446w_2bd4ea1ad1f89a23c242_72.png",
+                                                "image_96": "https://302674312496446w_2bd4ea1ad1f89a23c242_96.png",
+                                                "image_original": "https://302674446w12496_2bd4ea1ad1f89a23c242_original.png"
+                                            },
+                                            "id": "A0W7UKG8E",
+                                            "is_app_directory_approved": false,
+                                            "is_internal": false,
+                                            "name": "My Test App",
+                                            "privacy_policy_url": "https://www.slack.com"
+                                        },
+                                        "date_updated": 1574296707,
+                                        "last_resolved_by": {
+                                            "actor_id": "W0G82F4FD",
+                                            "actor_type": "user"
+                                        },
+                                        "scopes": [
+                                            {
+                                                "description": "Add the ability for people to direct message or mention @my_test_app",
+                                                "is_sensitive": true,
+                                                "name": "bot",
+                                                "token_type": "bot"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3006,6 +3067,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3078,6 +3145,64 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "app_requests": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://acmecorp.slack.com/apps/A061BL8RQ0-test-app",
+                                            "app_homepage_url": "",
+                                            "description": "",
+                                            "help_url": "",
+                                            "icons": {
+                                                "image_1024": "/cdn/15258203/img/testapp/service_1024.png",
+                                                "image_128": "/cdn/157258203/img/testapp/service_128.png",
+                                                "image_192": "/cdn/157258203/img/testapp/service_192.png",
+                                                "image_32": "/cdn/157658203/img/testapp/service_32.png",
+                                                "image_36": "/cdn/157658203/img/testapp/service_36.png",
+                                                "image_48": "/cdn/157658203/img/testapp/service_48.png",
+                                                "image_512": "/cdn/15758203/img/testapp/service_512.png",
+                                                "image_64": "/cdn/157658203/img/testapp/service_64.png",
+                                                "image_72": "/cdn/157658203/img/testapp/service_72.png",
+                                                "image_96": "/cdn/157658203/img/testapp/service_96.png"
+                                            },
+                                            "id": "A061BL8RQ0",
+                                            "is_app_directory_approved": true,
+                                            "is_internal": false,
+                                            "name": "Test App",
+                                            "privacy_policy_url": "https://testapp.com/privacy"
+                                        },
+                                        "date_created": 1578956327,
+                                        "id": "Ar0XJGFLMLS",
+                                        "message": "test test again",
+                                        "previous_resolution": null,
+                                        "scopes": [
+                                            {
+                                                "description": "Post messages to specific channels in Slack",
+                                                "is_sensitive": false,
+                                                "name": "incoming-webhook",
+                                                "token_type": "user"
+                                            }
+                                        ],
+                                        "team": {
+                                            "domain": "acmecorp",
+                                            "id": "T0M94LNUCR",
+                                            "name": "Acme Corp"
+                                        },
+                                        "user": {
+                                            "email": "janedoe@example.com",
+                                            "id": "W08RA9G5HR",
+                                            "name": "Jane Doe"
+                                        }
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3095,6 +3220,14 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "missing_scope",
+                                "needed": "admin.apps:read",
+                                "ok": false,
+                                "provided": "read,client,admin,identify,post,apps"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3168,6 +3301,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3185,6 +3323,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3262,6 +3406,56 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                },
+                                "restricted_apps": [
+                                    {
+                                        "app": {
+                                            "additional_info": "",
+                                            "app_directory_url": "https://myteam.enterprise.slack.com/apps/A0FDLP8M2L-my-test-app",
+                                            "app_homepage_url": "https://example.com",
+                                            "description": "A fun test app for Slack",
+                                            "help_url": "https://example.com",
+                                            "icons": {
+                                                "image_1024": "https://1433265338rl878408_eb57dbc818daa4ba15d6_1024.png",
+                                                "image_128": "https://4332653438rl87808_eb57dbc818daa4ba15d6_128.png",
+                                                "image_192": "https://4332653438rl87808_eb57dbc818daa4ba15d6_192.png",
+                                                "image_32": "https://143326534038rl8788_eb57dbc818daa4ba15d6_32.png",
+                                                "image_36": "https://143326534038rl8788_eb57dbc818daa4ba15d6_36.png",
+                                                "image_48": "https://143326534038rl8788_eb57dbc818daa4ba15d6_48.png",
+                                                "image_512": "https://4332653438rl87808_eb57dbc818daa4ba15d6_512.png",
+                                                "image_64": "https://143326534038rl8788_eb57dbc818daa4ba15d6_64.png",
+                                                "image_72": "https://143326534038rl8788_eb57dbc818daa4ba15d6_72.png",
+                                                "image_96": "https://143326534038rl8788_eb57dbc818daa4ba15d6_96.png",
+                                                "image_original": "https://143338rl8782653408_eb57dbc818daa4ba15d6_original.png"
+                                            },
+                                            "id": "A0FDLP8M2L",
+                                            "is_app_directory_approved": true,
+                                            "is_internal": false,
+                                            "name": "My Test App",
+                                            "privacy_policy_url": "https://example.com"
+                                        },
+                                        "date_updated": 1574296721,
+                                        "last_resolved_by": {
+                                            "actor_id": "W0G82LMFD",
+                                            "actor_type": "user"
+                                        },
+                                        "scopes": [
+                                            {
+                                                "description": "Upload, edit, and delete files on the user\u201fs behalf",
+                                                "is_sensitive": true,
+                                                "name": "files:write:user",
+                                                "token_type": "user"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3279,6 +3473,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3342,6 +3542,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.archive",
@@ -3359,6 +3564,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.archive",
@@ -3436,6 +3647,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.convertToPrivate",
@@ -3453,6 +3669,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.convertToPrivate",
@@ -3556,6 +3778,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel_id": "C12345",
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.create",
@@ -3576,6 +3804,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.create",
@@ -3653,6 +3887,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.delete",
@@ -3670,6 +3909,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.delete",
@@ -3753,6 +3998,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.disconnectShared",
@@ -3770,6 +4020,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.disconnectShared",
@@ -3868,6 +4124,19 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "id": "string",
+                                        "internal_team_ids": "array",
+                                        "original_connected_channel_id": "string",
+                                        "original_connected_host_id": "string"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -3885,6 +4154,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -3948,6 +4223,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.getConversationPrefs",
@@ -4004,6 +4284,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.getConversationPrefs",
@@ -4093,6 +4379,15 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "teams": [
+                                    "T1234",
+                                    "T5678"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.getTeams",
@@ -4129,6 +4424,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.getTeams",
@@ -4213,6 +4514,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.invite",
@@ -4230,6 +4536,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for error response from admin.conversations.invite",
@@ -4312,6 +4624,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.rename",
@@ -4329,6 +4646,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.rename",
@@ -4417,6 +4740,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4434,6 +4762,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4501,6 +4835,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "group_ids": [
+                                    "YOUR_GROUP_ID"
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4518,6 +4860,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4594,6 +4942,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4611,6 +4964,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -4709,6 +5068,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.search",
@@ -4733,6 +5135,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_enterprise",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.search",
@@ -4819,6 +5227,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.setConversationPrefs",
@@ -4836,6 +5249,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.setConversationPrefs",
@@ -4931,6 +5350,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -4948,6 +5372,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5011,6 +5441,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of admin.conversations.unarchive",
@@ -5028,6 +5463,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from admin.conversations.unarchive",
@@ -5111,6 +5552,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5128,6 +5574,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5197,6 +5649,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5214,6 +5671,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5281,6 +5744,43 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "cache_ts": "1575283387.000000",
+                                "categories": [
+                                    {
+                                        "emoji_names": [
+                                            "grinning",
+                                            "grin",
+                                            "joy",
+                                            "etc etc ..."
+                                        ],
+                                        "name": "Smileys & People"
+                                    }
+                                ],
+                                "categories_version": "5",
+                                "emoji": {
+                                    "black_square": "alias:black_large_square",
+                                    "bowtie": "https://emoji.slack-edge.com/T9TK3CUKW/bowtie/f3ec6f2bb0.png",
+                                    "cubimal_chick": "https://emoji.slack-edge.com/T9TK3CUKW/cubimal_chick/85961c43d7.png",
+                                    "dusty_stick": "https://emoji.slack-edge.com/T9TK3CUKW/dusty_stick/6177a62312.png",
+                                    "glitch_crab": "https://emoji.slack-edge.com/T9TK3CUKW/glitch_crab/db049f1f9c.png",
+                                    "piggy": "https://emoji.slack-edge.com/T9TK3CUKW/piggy/b7762ee8cd.png",
+                                    "pride": "https://emoji.slack-edge.com/T9TK3CUKW/pride/56b1bd3388.png",
+                                    "shipit": "alias:squirrel",
+                                    "simple_smile": {
+                                        "apple": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/apple/simple_smile.png",
+                                        "google": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/google/simple_smile.png"
+                                    },
+                                    "slack": "https://emoji.slack-edge.com/T9TK3CUKW/slack/7d462d2443.png",
+                                    "slack_call": "https://emoji.slack-edge.com/T9TK3CUKW/slack_call/b81fffd6dd.png",
+                                    "squirrel": "https://emoji.slack-edge.com/T9TK3CUKW/squirrel/465f40c0e0.png",
+                                    "thumbsup_all": "https://emoji.slack-edge.com/T9TK3CUKW/thumbsup_all/50096a1020.gif",
+                                    "white_square": "alias:white_large_square"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5298,6 +5798,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5360,6 +5866,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5377,6 +5888,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5446,6 +5963,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5463,6 +5985,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5532,6 +6060,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5549,6 +6082,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5623,6 +6162,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5640,6 +6184,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5714,6 +6264,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5731,6 +6286,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5800,6 +6361,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5817,6 +6383,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5891,6 +6463,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5908,6 +6485,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -5981,6 +6564,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "admin_ids": [
+                                    "U1234"
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -5998,6 +6589,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6080,6 +6677,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": "T12345"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6097,6 +6700,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6165,6 +6774,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "teams": [
+                                    {
+                                        "discoverability": "hidden",
+                                        "id": "T1234",
+                                        "name": "My Team",
+                                        "primary_owner": {
+                                            "email": "bront@slack.com",
+                                            "user_id": "W1234"
+                                        },
+                                        "team_url": "https://subarachnoid.slack.com/"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6182,6 +6808,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6255,6 +6887,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "owner_ids": [
+                                    "U1234"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6272,6 +6912,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6334,6 +6980,21 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "default_channels": "array",
+                                    "domain": "string",
+                                    "email_domain": "string",
+                                    "enterprise_id": "string",
+                                    "enterprise_name": "string",
+                                    "icon": "array",
+                                    "id": "string",
+                                    "name": "string"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6351,6 +7012,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6420,6 +7087,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6437,6 +7109,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6507,6 +7185,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6524,6 +7207,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6594,6 +7283,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6611,6 +7305,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6680,6 +7380,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6697,6 +7402,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6767,6 +7478,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6784,6 +7500,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6860,6 +7582,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6877,6 +7604,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -6953,6 +7686,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -6970,6 +7708,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7045,6 +7789,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "id": "C024BE91L",
+                                        "name": "fun",
+                                        "num_members": 34,
+                                        "team_id": "T024BE911"
+                                    },
+                                    {
+                                        "id": "C024BE91K",
+                                        "name": "more fun",
+                                        "team_id": "T024BE912"
+                                    },
+                                    {
+                                        "id": "C024BE91M",
+                                        "is_redacted": true,
+                                        "name": "public-channel",
+                                        "num_members": 34,
+                                        "team_id": "T024BE911"
+                                    },
+                                    {
+                                        "id": "C024BE91N",
+                                        "name": "some more fun",
+                                        "team_id": "T024BE921"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7062,6 +7836,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7132,6 +7912,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7149,6 +7934,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the token provided is not associated with an Org Admin or Owner",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_an_admin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7237,6 +8028,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7254,6 +8050,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7367,6 +8169,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7384,6 +8191,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7459,6 +8272,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": [
+                                    {
+                                        "email": "bront@slack.com",
+                                        "id": "T1234",
+                                        "is_admin": false,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7476,6 +8306,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7546,6 +8382,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7563,6 +8404,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7632,6 +8479,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7649,6 +8501,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7724,6 +8582,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7741,6 +8604,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7811,6 +8680,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7828,6 +8702,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7905,6 +8785,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -7922,6 +8807,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -7992,6 +8883,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8009,6 +8905,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8079,6 +8981,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8096,6 +9003,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8157,6 +9070,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -8176,6 +9094,15 @@
                     },
                     "default": {
                         "description": "Artificial error response",
+                        "examples": {
+                            "application/json": {
+                                "args": {
+                                    "error": "my_error"
+                                },
+                                "error": "my_error",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -8253,6 +9180,17 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "authorizations": {
+                                    "enterprise_id": "string",
+                                    "is_bot": "string",
+                                    "team_id": "string",
+                                    "user_id": "string"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8270,6 +9208,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -8324,6 +9268,62 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "info": {
+                                    "app_home": {
+                                        "resources": {
+                                            "ids": [
+                                                "D0C0NU1Q8",
+                                                "D0BH95DLH"
+                                            ]
+                                        },
+                                        "scopes": [
+                                            "chat:write",
+                                            "im:history",
+                                            "im:read"
+                                        ]
+                                    },
+                                    "channel": {
+                                        "resources": {
+                                            "excluded_ids": [],
+                                            "ids": [
+                                                "C061FA5PB"
+                                            ],
+                                            "wildcard": false
+                                        },
+                                        "scopes": [
+                                            "channels:read"
+                                        ]
+                                    },
+                                    "group": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "im": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "mpim": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    },
+                                    "team": {
+                                        "resources": {
+                                            "ids": []
+                                        },
+                                        "scopes": []
+                                    }
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.permissions.info method",
@@ -8425,6 +9425,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.info method",
@@ -8523,6 +9529,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.permissions.request method",
@@ -8540,6 +9551,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when trigger_id is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_trigger_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.request method",
@@ -8640,6 +9657,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "resources": [
+                                    {
+                                        "id": "T0DES3UAN",
+                                        "type": "team"
+                                    },
+                                    {
+                                        "id": "D024BFF1M",
+                                        "type": "app_home"
+                                    },
+                                    {
+                                        "id": "C024BE91L",
+                                        "type": "channel"
+                                    }
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response apps.permissions.resources.list method",
@@ -8698,6 +9737,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.resources.list method",
@@ -8783,6 +9828,35 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "scopes": {
+                                    "app_home": [
+                                        "chat:write",
+                                        "im:history",
+                                        "im:read"
+                                    ],
+                                    "channel": [
+                                        "channels:history",
+                                        "chat:write"
+                                    ],
+                                    "group": [
+                                        "chat:write"
+                                    ],
+                                    "im": [
+                                        "chat:write"
+                                    ],
+                                    "mpim": [
+                                        "chat:write"
+                                    ],
+                                    "team": [
+                                        "users:read"
+                                    ],
+                                    "user": []
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response api.permissions.scopes.list method",
@@ -8828,6 +9902,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.permissions.scopes.list method",
@@ -8924,6 +10004,29 @@
                 "responses": {
                     "200": {
                         "description": "Typical successful paginated response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "resources": [
+                                    {
+                                        "id": "U0DES3UAN",
+                                        "scopes": [
+                                            "dnd:write:user",
+                                            "reminders:write:user"
+                                        ]
+                                    },
+                                    {
+                                        "id": "U024BFF1M",
+                                        "scopes": [
+                                            "reminders:write:user"
+                                        ]
+                                    }
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTdPMUg5UkFTT0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -8941,6 +10044,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9017,6 +10126,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9034,6 +10148,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when trigger_id is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_trigger_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9100,6 +10220,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from apps.uninstall method",
@@ -9117,6 +10242,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from apps.uninstall method",
@@ -9209,6 +10340,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "revoked": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from auth.revoke method",
@@ -9230,6 +10367,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from auth.revoke method",
@@ -9313,6 +10456,16 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": "Subarachnoid Workspace",
+                                "team_id": "T12345678",
+                                "url": "https://subarachnoid.slack.com/",
+                                "user": "grace",
+                                "user_id": "W12345678"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response auth.test method",
@@ -9356,6 +10509,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response auth.test method",
@@ -9440,6 +10599,24 @@
                 "responses": {
                     "200": {
                         "description": "When successful, returns bot info by bot ID.",
+                        "examples": {
+                            "application/json": {
+                                "bot": {
+                                    "app_id": "A161CLERW",
+                                    "deleted": false,
+                                    "icons": {
+                                        "image_36": "https://...",
+                                        "image_48": "https://...",
+                                        "image_72": "https://..."
+                                    },
+                                    "id": "B061F7JD2",
+                                    "name": "beforebot",
+                                    "updated": 1449272004,
+                                    "user_id": "U012ABCDEF"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from bots.info method",
@@ -9513,6 +10690,12 @@
                     },
                     "default": {
                         "description": "When no bot can be found, it returns an error.",
+                        "examples": {
+                            "application/json": {
+                                "error": "bot_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from bots.info method",
@@ -9647,6 +10830,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9664,6 +10852,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9732,6 +10926,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9749,6 +10948,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9811,6 +11016,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9828,6 +11038,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9897,6 +11113,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -9914,6 +11135,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -9984,6 +11211,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -10001,6 +11233,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -10082,6 +11320,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -10099,6 +11342,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -10171,6 +11420,13 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE91L",
+                                "ok": true,
+                                "ts": "1401383885.000061"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.delete method",
@@ -10196,6 +11452,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "message_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.delete method",
@@ -10303,6 +11565,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.deleteScheduledMessage method",
@@ -10320,6 +11587,12 @@
                     },
                     "default": {
                         "description": "Typical error response if no message is found",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_scheduled_message_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.deleteScheduledMessage method",
@@ -10422,6 +11695,13 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGA",
+                                "ok": true,
+                                "permalink": "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response chat.getPermalink",
@@ -10448,6 +11728,12 @@
                     },
                     "default": {
                         "description": "Error response when channel cannot be found",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.getPermalink method",
@@ -10544,6 +11830,13 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE7LR",
+                                "ok": true,
+                                "ts": "1417671948.000006"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.meMessage method",
@@ -10567,6 +11860,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.meMessage method",
@@ -10731,6 +12030,12 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "message_ts": "1502210682.580145",
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.postEphemeral method",
@@ -10752,6 +12057,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_in_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.postEphemeral method",
@@ -10934,6 +12245,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGL",
+                                "message": {
+                                    "attachments": [
+                                        {
+                                            "fallback": "This is an attachment's fallback",
+                                            "id": 1,
+                                            "text": "This is an attachment"
+                                        }
+                                    ],
+                                    "bot_id": "B19LU7CSY",
+                                    "subtype": "bot_message",
+                                    "text": "Here's a message for you",
+                                    "ts": "1503435956.000247",
+                                    "type": "message",
+                                    "username": "ecto1"
+                                },
+                                "ok": true,
+                                "ts": "1503435956.000247"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.postMessage method",
@@ -10963,6 +12296,12 @@
                     },
                     "default": {
                         "description": "Typical error response if too many attachments are included",
+                        "examples": {
+                            "application/json": {
+                                "error": "too_many_attachments",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.postMessage method",
@@ -11116,6 +12455,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C1H9RESGL",
+                                "message": {
+                                    "attachments": [
+                                        {
+                                            "fallback": "This is an attachment's fallback",
+                                            "id": 1,
+                                            "text": "This is an attachment"
+                                        }
+                                    ],
+                                    "bot_id": "B19LU7CSY",
+                                    "subtype": "bot_message",
+                                    "text": "Here's a message for you in the future",
+                                    "type": "delayed_message",
+                                    "username": "ecto1"
+                                },
+                                "ok": true,
+                                "post_at": "1562180400",
+                                "scheduled_message_id": "Q1298393284"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.scheduleMessage method",
@@ -11183,6 +12544,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the `post_at` is invalid (ex. in the past or too far into the future)",
+                        "examples": {
+                            "application/json": {
+                                "error": "time_in_past",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.scheduleMessage method",
@@ -11312,6 +12679,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": ""
+                                },
+                                "scheduled_messages": [
+                                    {
+                                        "channel_id": "C1H9RESGL",
+                                        "date_created": 1551891734,
+                                        "id": 1298393284,
+                                        "post_at": 1551991428,
+                                        "text": "Here's a message for you in the future"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.scheduledMessages.list method",
@@ -11376,6 +12760,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the channel passed is invalid",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.scheduledMessages.list method",
@@ -11501,6 +12891,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical, minimal success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from chat.unfurl method",
@@ -11518,6 +12913,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "cannot_unfurl_url",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from chat.unfurl method",
@@ -11656,6 +13057,18 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": "C024BE91L",
+                                "message": {
+                                    "text": "Updated text you carefully authored",
+                                    "user": "U34567890"
+                                },
+                                "ok": true,
+                                "text": "Updated text you carefully authored",
+                                "ts": "1401383885.000061"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response of chat.update method",
@@ -11707,6 +13120,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_update_message",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response chat.update method",
@@ -11803,6 +13222,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.archive method",
@@ -11820,6 +13244,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.archive method",
@@ -11925,6 +13355,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.close method",
@@ -11948,6 +13383,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.close method",
@@ -12051,6 +13492,48 @@
                 "responses": {
                     "200": {
                         "description": "If successful, the command returns a rather stark [conversation object](/types/conversation)",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1504554479,
+                                    "creator": "U0123456",
+                                    "id": "C0EAQDV4Z",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": false,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_shared": false,
+                                    "last_read": "0000000000.000000",
+                                    "latest": null,
+                                    "name": "endeavor",
+                                    "name_normalized": "endeavor",
+                                    "pending_shared": [],
+                                    "previous_names": [],
+                                    "priority": 0,
+                                    "purpose": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": ""
+                                    },
+                                    "topic": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": ""
+                                    },
+                                    "unlinked": 0,
+                                    "unread_count": 0,
+                                    "unread_count_display": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.create method",
@@ -12072,6 +13555,12 @@
                     },
                     "default": {
                         "description": "Typical error response when name already in use",
+                        "examples": {
+                            "application/json": {
+                                "error": "name_taken",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.create method",
@@ -12209,6 +13698,30 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response containing a channel's messages",
+                        "examples": {
+                            "application/json": {
+                                "has_more": true,
+                                "messages": [
+                                    {
+                                        "text": "I find you punny and would like to smell your nose letter",
+                                        "ts": "1512085950.000216",
+                                        "type": "message",
+                                        "user": "U012AB3CDE"
+                                    },
+                                    {
+                                        "text": "What, you want to smell my shoes better?",
+                                        "ts": "1512104434.000490",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    }
+                                ],
+                                "ok": true,
+                                "pin_count": 0,
+                                "response_metadata": {
+                                    "next_cursor": "bmV4dF90czoxNTEyMDg1ODYxMDAwNTQz"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.history method",
@@ -12258,6 +13771,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.history method",
@@ -12365,6 +13884,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response for a public channel. (Also, a response from a private channel and a multi-party IM is very similar to this example.)",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "parent_conversation": null,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "specifics",
+                                        "abstractions",
+                                        "etc"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.info",
@@ -12386,6 +13950,12 @@
                     },
                     "default": {
                         "description": "Typical error response when a channel cannot be found",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.info method",
@@ -12487,6 +14057,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response when an invitation is extended",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "num_members": 23,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "specifics",
+                                        "abstractions",
+                                        "etc"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.invite method",
@@ -12508,6 +14123,12 @@
                     },
                     "default": {
                         "description": "Typical error response when an invite is attempted on a conversation type that does not support it",
+                        "examples": {
+                            "application/json": {
+                                "error": "method_not_supported_for_channel_type",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.invite method",
@@ -12675,6 +14296,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "U061F7AUR",
+                                    "id": "C061EG9SL",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_shared": false,
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "pending_shared": [],
+                                    "previous_names": [],
+                                    "purpose": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": "For widget discussion"
+                                    },
+                                    "topic": {
+                                        "creator": "",
+                                        "last_set": 0,
+                                        "value": "Which widget do you worry about?"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true,
+                                "response_metadata": {
+                                    "warnings": [
+                                        "already_in_channel"
+                                    ]
+                                },
+                                "warning": "already_in_channel"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.join method",
@@ -12713,6 +14377,12 @@
                     },
                     "default": {
                         "description": "Typical error response if the conversation is archived and cannot be joined",
+                        "examples": {
+                            "application/json": {
+                                "error": "is_archived",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.join method",
@@ -12818,6 +14488,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.kick method",
@@ -12835,6 +14510,12 @@
                     },
                     "default": {
                         "description": "Typical error response when you attempt to kick yourself from a channel",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_kick_self",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response conversations.kick method",
@@ -12937,6 +14618,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.leave method",
@@ -12960,6 +14646,12 @@
                     },
                     "default": {
                         "description": "Typical error response when attempting to leave a workspace's \"general\" channel",
+                        "examples": {
+                            "application/json": {
+                                "error": "cant_leave_general",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.leave method",
@@ -13081,6 +14773,82 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response with only public channels",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    },
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U061F7AUR",
+                                        "id": "C061EG9T2",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": false,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_member": true,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "random",
+                                        "name_normalized": "random",
+                                        "num_members": 4,
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Non-work banter and water cooler conversation"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.list method",
@@ -13118,6 +14886,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.list method",
@@ -13217,6 +14991,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.mark method",
@@ -13234,6 +15013,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.mark method",
@@ -13343,6 +15128,19 @@
                 "responses": {
                     "200": {
                         "description": "Typical paginated success response",
+                        "examples": {
+                            "application/json": {
+                                "members": [
+                                    "U023BECGF",
+                                    "U061F7AUR",
+                                    "W012A3CDE"
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "e3VzZXJfaWQ6IFcxMjM0NTY3fQ=="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response conversations.members method",
@@ -13382,6 +15180,12 @@
                     },
                     "default": {
                         "description": "Typical error response when an invalid cursor is provided",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response conversations.members method",
@@ -13485,6 +15289,14 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "id": "D069C7QFK"
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.open method when opening channels, ims, mpims",
@@ -13552,6 +15364,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.open method",
@@ -13654,6 +15472,51 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "channel": {
+                                    "created": 1449252889,
+                                    "creator": "W012A3BCD",
+                                    "id": "C012AB3CD",
+                                    "is_archived": false,
+                                    "is_channel": true,
+                                    "is_ext_shared": false,
+                                    "is_general": true,
+                                    "is_group": false,
+                                    "is_im": false,
+                                    "is_member": true,
+                                    "is_mpim": false,
+                                    "is_org_shared": false,
+                                    "is_pending_ext_shared": false,
+                                    "is_private": false,
+                                    "is_read_only": false,
+                                    "is_shared": false,
+                                    "last_read": "1502126650.228446",
+                                    "locale": "en-US",
+                                    "name": "general",
+                                    "name_normalized": "general",
+                                    "num_members": 23,
+                                    "pending_shared": [],
+                                    "previous_names": [
+                                        "specifics",
+                                        "abstractions",
+                                        "etc"
+                                    ],
+                                    "purpose": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "This part of the workspace is for fun. Make fun here."
+                                    },
+                                    "topic": {
+                                        "creator": "W012A3BCD",
+                                        "last_set": 1449709364,
+                                        "value": "For public discussion of generalities"
+                                    },
+                                    "unlinked": 0
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.rename method",
@@ -13675,6 +15538,12 @@
                     },
                     "default": {
                         "description": "Typical error response when the calling user is not a member of the conversation",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_in_channel",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.rename method",
@@ -13814,6 +15683,52 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "has_more": true,
+                                "messages": [
+                                    {
+                                        "last_read": "1484678597.521003",
+                                        "reply_count": 3,
+                                        "subscribed": true,
+                                        "text": "island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1482960137.003543",
+                                        "type": "message",
+                                        "unread_count": 0,
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "one island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483037603.017503",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "two island",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483051909.018632",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    },
+                                    {
+                                        "parent_user_id": "U061F7AUR",
+                                        "text": "three for the land",
+                                        "thread_ts": "1482960137.003543",
+                                        "ts": "1483125339.020269",
+                                        "type": "message",
+                                        "user": "U061F7AUR"
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "bmV4dF90czoxNDg0Njc4MjkwNTE3MDkx"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.replies method",
@@ -13956,6 +15871,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "thread_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.replies method",
@@ -14058,6 +15979,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.setPurpose method",
@@ -14079,6 +16005,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.setPurpose method",
@@ -14185,6 +16117,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.setTopic method",
@@ -14206,6 +16143,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.setTopic method",
@@ -14306,6 +16249,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from conversations.unarchive method",
@@ -14323,6 +16271,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from conversations.unarchive method",
@@ -14434,6 +16388,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response is quite minimal.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dialog.open method",
@@ -14451,6 +16410,12 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "missing_trigger",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dialog.open method",
@@ -14543,6 +16508,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.endDnd method",
@@ -14560,6 +16530,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.endDnd method",
@@ -14645,6 +16621,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.endSnooze method",
@@ -14678,6 +16659,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.endSnooze method",
@@ -14768,6 +16755,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.info method",
@@ -14806,6 +16798,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.info method",
@@ -14896,6 +16894,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from dnd.setSnooze method",
@@ -14925,6 +16928,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from dnd.setSnooze method",
@@ -15016,6 +17025,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": {
+                                    "U023BECGF": {
+                                        "dnd_enabled": true,
+                                        "next_dnd_end_ts": 1450423800,
+                                        "next_dnd_start_ts": 1450387800
+                                    },
+                                    "W058CJVAA": {
+                                        "dnd_enabled": false,
+                                        "next_dnd_end_ts": 1,
+                                        "next_dnd_start_ts": 1
+                                    }
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15033,6 +17059,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15087,6 +17119,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15104,6 +17141,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15170,6 +17213,11 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response is very simple",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.comments.delete method",
@@ -15187,6 +17235,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "file_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.comments.delete method",
@@ -15274,6 +17328,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.delete method",
@@ -15291,6 +17350,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.delete method",
@@ -15400,6 +17465,77 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "comments": [],
+                                "file": {
+                                    "channels": [
+                                        "C0T8SE4AU"
+                                    ],
+                                    "comments_count": 0,
+                                    "created": 1531763342,
+                                    "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+                                    "display_as_bot": false,
+                                    "editable": false,
+                                    "external_type": "",
+                                    "filetype": "gif",
+                                    "groups": [],
+                                    "has_rich_preview": false,
+                                    "id": "F0S43PZDF",
+                                    "image_exif_rotation": 1,
+                                    "ims": [],
+                                    "is_external": false,
+                                    "is_public": true,
+                                    "is_starred": false,
+                                    "mimetype": "image/gif",
+                                    "mode": "hosted",
+                                    "name": "tedair.gif",
+                                    "original_h": 226,
+                                    "original_w": 176,
+                                    "permalink": "https://.../tedair.gif",
+                                    "permalink_public": "https://.../...",
+                                    "pjpeg": "https://.../tedair_pjpeg.jpg",
+                                    "pretty_type": "GIF",
+                                    "public_url_shared": false,
+                                    "shares": {
+                                        "public": {
+                                            "C0T8SE4AU": [
+                                                {
+                                                    "channel_name": "file-under",
+                                                    "latest_reply": "1531763348.000001",
+                                                    "reply_count": 1,
+                                                    "reply_users": [
+                                                        "U061F7AUR"
+                                                    ],
+                                                    "reply_users_count": 1,
+                                                    "team_id": "T061EG9R6",
+                                                    "thread_ts": "1531763273.000015",
+                                                    "ts": "1531763348.000001"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "size": 137531,
+                                    "thumb_160": "https://.../tedair_=_160.png",
+                                    "thumb_360": "https://.../tedair_360.png",
+                                    "thumb_360_gif": "https://.../tedair_360.gif",
+                                    "thumb_360_h": 226,
+                                    "thumb_360_w": 176,
+                                    "thumb_64": "https://.../tedair_64.png",
+                                    "thumb_80": "https://.../tedair_80.png",
+                                    "timestamp": 1531763342,
+                                    "title": "tedair.gif",
+                                    "url_private": "https://.../tedair.gif",
+                                    "url_private_download": "https://.../tedair.gif",
+                                    "user": "U061F7AUR",
+                                    "username": ""
+                                },
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.info method",
@@ -15437,6 +17573,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.info method",
@@ -15564,6 +17706,103 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "files": [
+                                    {
+                                        "channels": [
+                                            "C0T8SE4AU"
+                                        ],
+                                        "comments_count": 0,
+                                        "created": 1531763254,
+                                        "deanimate_gif": "https://.../billair_deanimate_gif.png",
+                                        "display_as_bot": false,
+                                        "editable": false,
+                                        "external_type": "",
+                                        "filetype": "gif",
+                                        "groups": [],
+                                        "id": "F0S43P1CZ",
+                                        "image_exif_rotation": 1,
+                                        "ims": [],
+                                        "is_external": false,
+                                        "is_public": true,
+                                        "mimetype": "image/gif",
+                                        "mode": "hosted",
+                                        "name": "billair.gif",
+                                        "original_h": 226,
+                                        "original_w": 176,
+                                        "permalink": "https://.../billair.gif",
+                                        "permalink_public": "https://.../...",
+                                        "pjpeg": "https://.../billair_pjpeg.jpg",
+                                        "pretty_type": "GIF",
+                                        "public_url_shared": false,
+                                        "size": 144538,
+                                        "thumb_160": "https://.../billair_=_160.png",
+                                        "thumb_360": "https://.../billair_360.png",
+                                        "thumb_360_gif": "https://.../billair_360.gif",
+                                        "thumb_360_h": 226,
+                                        "thumb_360_w": 176,
+                                        "thumb_64": "https://.../billair_64.png",
+                                        "thumb_80": "https://.../billair_80.png",
+                                        "timestamp": 1531763254,
+                                        "title": "billair.gif",
+                                        "url_private": "https://.../billair.gif",
+                                        "url_private_download": "https://.../billair.gif",
+                                        "user": "U061F7AUR",
+                                        "username": ""
+                                    },
+                                    {
+                                        "channels": [
+                                            "C0T8SE4AU"
+                                        ],
+                                        "comments_count": 0,
+                                        "created": 1531763342,
+                                        "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+                                        "display_as_bot": false,
+                                        "editable": false,
+                                        "external_type": "",
+                                        "filetype": "gif",
+                                        "groups": [],
+                                        "id": "F0S43PZDF",
+                                        "image_exif_rotation": 1,
+                                        "ims": [],
+                                        "is_external": false,
+                                        "is_public": true,
+                                        "mimetype": "image/gif",
+                                        "mode": "hosted",
+                                        "name": "tedair.gif",
+                                        "original_h": 226,
+                                        "original_w": 176,
+                                        "permalink": "https://.../tedair.gif",
+                                        "permalink_public": "https://.../...",
+                                        "pjpeg": "https://.../tedair_pjpeg.jpg",
+                                        "pretty_type": "GIF",
+                                        "public_url_shared": false,
+                                        "size": 137531,
+                                        "thumb_160": "https://.../tedair_=_160.png",
+                                        "thumb_360": "https://.../tedair_360.png",
+                                        "thumb_360_gif": "https://.../tedair_360.gif",
+                                        "thumb_360_h": 226,
+                                        "thumb_360_w": 176,
+                                        "thumb_64": "https://.../tedair_64.png",
+                                        "thumb_80": "https://.../tedair_80.png",
+                                        "timestamp": 1531763342,
+                                        "title": "tedair.gif",
+                                        "url_private": "https://.../tedair.gif",
+                                        "url_private_download": "https://.../tedair.gif",
+                                        "user": "U061F7AUR",
+                                        "username": ""
+                                    }
+                                ],
+                                "ok": true,
+                                "paging": {
+                                    "count": 100,
+                                    "page": 1,
+                                    "pages": 1,
+                                    "total": 2
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.list method",
@@ -15594,6 +17833,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.list method",
@@ -15711,6 +17956,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15728,6 +17978,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15794,6 +18050,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15811,6 +18072,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15895,6 +18162,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15912,6 +18184,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -15978,6 +18256,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -15995,6 +18278,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16067,6 +18356,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16084,6 +18378,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16180,6 +18480,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16197,6 +18502,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16258,6 +18569,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.revokePublicURL method",
@@ -16279,6 +18595,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.revokePublicURL method",
@@ -16370,6 +18692,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from files.sharedPublicURL method",
@@ -16391,6 +18718,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from files.sharedPublicURL method",
@@ -16524,6 +18857,67 @@
                 "responses": {
                     "200": {
                         "description": "Success response after uploading a file to a channel with an initial message",
+                        "examples": {
+                            "application/json": {
+                                "file": {
+                                    "channels": [],
+                                    "comments_count": 0,
+                                    "created": 1532293501,
+                                    "display_as_bot": false,
+                                    "editable": false,
+                                    "external_type": "",
+                                    "filetype": "gif",
+                                    "groups": [],
+                                    "has_rich_preview": false,
+                                    "id": "F0TD00400",
+                                    "image_exif_rotation": 1,
+                                    "ims": [
+                                        "D0L4B9P0Q"
+                                    ],
+                                    "is_external": false,
+                                    "is_public": false,
+                                    "is_starred": false,
+                                    "mimetype": "image/jpeg",
+                                    "mode": "hosted",
+                                    "name": "dramacat.gif",
+                                    "original_h": 366,
+                                    "original_w": 526,
+                                    "permalink": "https://.../dramacat.gif",
+                                    "permalink_public": "https://.../More-Path-Components",
+                                    "pretty_type": "JPEG",
+                                    "public_url_shared": false,
+                                    "shares": {
+                                        "private": {
+                                            "D0L4B9P0Q": [
+                                                {
+                                                    "reply_count": 0,
+                                                    "reply_users": [],
+                                                    "reply_users_count": 0,
+                                                    "ts": "1532293503.000001"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "size": 43518,
+                                    "thumb_160": "https://.../dramacat_160.gif",
+                                    "thumb_360": "https://.../dramacat_360.gif",
+                                    "thumb_360_h": 250,
+                                    "thumb_360_w": 360,
+                                    "thumb_480": "https://.../dramacat_480.gif",
+                                    "thumb_480_h": 334,
+                                    "thumb_480_w": 480,
+                                    "thumb_64": "https://.../dramacat_64.gif",
+                                    "thumb_80": "https://.../dramacat_80.gif",
+                                    "timestamp": 1532293501,
+                                    "title": "dramacat",
+                                    "url_private": "https://.../dramacat.gif",
+                                    "url_private_download": "https://.../dramacat.gif",
+                                    "user": "U0L4B9NSU",
+                                    "username": ""
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response files.upload method",
@@ -16545,6 +18939,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response files.upload method",
@@ -16558,7 +18958,6 @@
                                         "posting_to_general_channel_denied",
                                         "invalid_channel",
                                         "file_uploads_disabled",
-                                        "file_upload_size_restricted",
                                         "file_uploads_except_images_disabled",
                                         "storage_limit_reached",
                                         "not_authed",
@@ -16649,6 +19048,23 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response when mappings exist for the specified user IDs",
+                        "examples": {
+                            "application/json": {
+                                "enterprise_id": "E1KQTNXE1",
+                                "invalid_user_ids": [
+                                    "U21ABZZXX"
+                                ],
+                                "ok": true,
+                                "team_id": "T1KR7PE1W",
+                                "user_id_map": {
+                                    "U06UBSUN5": "W06M56XJM",
+                                    "U06UBSVB3": "W06PUUDLY",
+                                    "U06UBSVDX": "W06PUUDMW",
+                                    "U06UEB62U": "W06PTT6GH",
+                                    "W06UAZ65Q": "W06UAZ65Q"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from migration.exchange method",
@@ -16687,6 +19103,12 @@
                     },
                     "default": {
                         "description": "Typical error response when there are no mappings to provide",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_enterprise_team",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from migration.exchange method",
@@ -16794,6 +19216,15 @@
                 "responses": {
                     "200": {
                         "description": "Successful user token negotiation for a single scope",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
+                                "enterprise_id": null,
+                                "scope": "groups:write",
+                                "team_id": "TXXXXXXXXX",
+                                "team_name": "Wyld Stallyns LLC"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16811,6 +19242,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16888,6 +19325,30 @@
                 "responses": {
                     "200": {
                         "description": "Success example using a workspace app produces a very different kind of response",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxa-access-token-string",
+                                "app_id": "A012345678",
+                                "app_user_id": "U0AB12ABC",
+                                "authorizing_user_id": "U0HTT3Q0G",
+                                "installer_user_id": "U061F7AUR",
+                                "ok": true,
+                                "permissions": [
+                                    {
+                                        "resource_id": 0,
+                                        "resource_type": "channel",
+                                        "scopes": [
+                                            "channels:read",
+                                            "chat:write:user"
+                                        ]
+                                    }
+                                ],
+                                "single_channel_id": "C061EG9T2",
+                                "team_id": "T061EG9Z9",
+                                "team_name": "Subarachnoid Workspace",
+                                "token_type": "app"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16905,6 +19366,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -16977,6 +19444,30 @@
                 "responses": {
                     "200": {
                         "description": "Successful token request with scopes for both a bot user and a user token",
+                        "examples": {
+                            "application/json": {
+                                "access_token": "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+                                "app_id": "A0KRD7HC3",
+                                "authed_user": {
+                                    "access_token": "xoxp-1234",
+                                    "id": "U1234",
+                                    "scope": "chat:write",
+                                    "token_type": "user"
+                                },
+                                "bot_user_id": "U0KRQLJ9H",
+                                "enterprise": {
+                                    "id": "E12345678",
+                                    "name": "slack-sports"
+                                },
+                                "ok": true,
+                                "scope": "commands,incoming-webhook",
+                                "team": {
+                                    "id": "T9TK3CUKW",
+                                    "name": "Slack Softball Team"
+                                },
+                                "token_type": "bot"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -16994,6 +19485,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_client_id",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -17063,6 +19560,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from pins.add method",
@@ -17080,6 +19582,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "channel_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.add method",
@@ -17174,6 +19682,45 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "items": [
+                                    {
+                                        "channel": "C2U86NC6H",
+                                        "created": 1508881078,
+                                        "created_by": "U2U85N1RZ",
+                                        "message": {
+                                            "permalink": "https://hitchhikers.slack.com/archives/C2U86NC6H/p1508197641000151",
+                                            "pinned_to": [
+                                                "C2U86NC6H"
+                                            ],
+                                            "text": "What is the meaning of life?",
+                                            "ts": "1508197641.000151",
+                                            "type": "message",
+                                            "user": "U2U85N1RZ"
+                                        },
+                                        "type": "message"
+                                    },
+                                    {
+                                        "channel": "C2U86NC6H",
+                                        "created": 1508880991,
+                                        "created_by": "U2U85N1RZ",
+                                        "message": {
+                                            "permalink": "https://hitchhikers.slack.com/archives/C2U86NC6H/p1508284197000015",
+                                            "pinned_to": [
+                                                "C2U86NC6H"
+                                            ],
+                                            "text": "The meaning of life, the universe, and everything is 42.",
+                                            "ts": "1503289197.000015",
+                                            "type": "message",
+                                            "user": "U2U85N1RZ"
+                                        },
+                                        "type": "message"
+                                    }
+                                ],
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from pins.list method",
                             "items": [
@@ -17265,6 +19812,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.list method",
@@ -17359,6 +19912,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from pins.remove method",
@@ -17376,6 +19934,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "no_pin",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from pins.remove method",
@@ -17484,6 +20048,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.add method",
@@ -17501,6 +20070,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "already_reacted",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.add method",
@@ -17617,6 +20192,35 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "file": {
+                                    "channels": [
+                                        "C2U7V2YA2"
+                                    ],
+                                    "comments_count": 1,
+                                    "created": 1507850315,
+                                    "groups": [],
+                                    "id": "F7H0D7ZA4",
+                                    "ims": [],
+                                    "name": "computer.gif",
+                                    "reactions": [
+                                        {
+                                            "count": 1,
+                                            "name": "stuck_out_tongue_winking_eye",
+                                            "users": [
+                                                "U2U85N1RV"
+                                            ]
+                                        }
+                                    ],
+                                    "timestamp": 1507850315,
+                                    "title": "computer.gif",
+                                    "user": "U2U85N1RV"
+                                },
+                                "ok": true,
+                                "type": "file"
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from reactions.get method",
                             "items": [
@@ -17701,6 +20305,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.get method",
@@ -17818,6 +20428,99 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "items": [
+                                    {
+                                        "channel": "C3UKJTQAC",
+                                        "message": {
+                                            "bot_id": "B4VLRLMKJ",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "robot_face",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "subtype": "bot_message",
+                                            "text": "Hello from Python! :tada:",
+                                            "ts": "1507849573.000090",
+                                            "username": "Shipit Notifications"
+                                        },
+                                        "type": "message"
+                                    },
+                                    {
+                                        "comment": {
+                                            "comment": "This is a file comment",
+                                            "created": 1508286096,
+                                            "id": "Fc7LP08P1U",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "white_check_mark",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "timestamp": 1508286096,
+                                            "type": "file_comment",
+                                            "user": "U2U85N1RV"
+                                        },
+                                        "file": {
+                                            "channels": [
+                                                "C2U7V2YA2"
+                                            ],
+                                            "comments_count": 1,
+                                            "created": 1507850315,
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "stuck_out_tongue_winking_eye",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "title": "computer.gif",
+                                            "user": "U2U85N1RV",
+                                            "username": ""
+                                        }
+                                    },
+                                    {
+                                        "file": {
+                                            "channels": [
+                                                "C2U7V2YA2"
+                                            ],
+                                            "comments_count": 1,
+                                            "created": 1507850315,
+                                            "id": "F7H0D7ZA4",
+                                            "name": "computer.gif",
+                                            "reactions": [
+                                                {
+                                                    "count": 1,
+                                                    "name": "stuck_out_tongue_winking_eye",
+                                                    "users": [
+                                                        "U2U85N1RV"
+                                                    ]
+                                                }
+                                            ],
+                                            "size": 1639034,
+                                            "title": "computer.gif",
+                                            "user": "U2U85N1RV",
+                                            "username": ""
+                                        },
+                                        "type": "file"
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMUg5UkVTR0w="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.list method",
@@ -17914,6 +20617,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.list method",
@@ -18027,6 +20736,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reactions.remove method",
@@ -18044,6 +20758,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "no_reaction",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reactions.remove method",
@@ -18152,6 +20872,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.add method",
@@ -18173,6 +20898,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.add method",
@@ -18268,6 +20999,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.complete method",
@@ -18285,6 +21021,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.complete method",
@@ -18377,6 +21119,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.delete method",
@@ -18394,6 +21141,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.delete method",
@@ -18483,6 +21236,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.info method",
@@ -18504,6 +21262,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.info method",
@@ -18587,6 +21351,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from reminders.list method",
@@ -18611,6 +21380,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from reminders.list method",
@@ -18706,6 +21481,21 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "self": {
+                                    "id": "U4X318ZMZ",
+                                    "name": "robotoverlord"
+                                },
+                                "team": {
+                                    "domain": "slackdemo",
+                                    "id": "T2U81E2FP",
+                                    "name": "SlackDemo"
+                                },
+                                "url": "wss://..."
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from rtm.connect method",
@@ -18766,6 +21556,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from rtm.connect method",
@@ -18883,6 +21679,73 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "messages": {
+                                    "matches": [
+                                        {
+                                            "channel": {
+                                                "id": "C12345678",
+                                                "is_ext_shared": false,
+                                                "is_mpim": false,
+                                                "is_org_shared": false,
+                                                "is_pending_ext_shared": false,
+                                                "is_private": false,
+                                                "is_shared": false,
+                                                "name": "general",
+                                                "pending_shared": []
+                                            },
+                                            "iid": "cb64bdaa-c1e8-4631-8a91-0f78080113e9",
+                                            "permalink": "https://hitchhikers.slack.com/archives/C12345678/p1508284197000015",
+                                            "team": "T12345678",
+                                            "text": "The meaning of life the universe and everything is 42.",
+                                            "ts": "1508284197.000015",
+                                            "type": "message",
+                                            "user": "U2U85N1RV",
+                                            "username": "roach"
+                                        },
+                                        {
+                                            "channel": {
+                                                "id": "C12345678",
+                                                "is_ext_shared": false,
+                                                "is_mpim": false,
+                                                "is_org_shared": false,
+                                                "is_pending_ext_shared": false,
+                                                "is_private": false,
+                                                "is_shared": false,
+                                                "name": "random",
+                                                "pending_shared": []
+                                            },
+                                            "iid": "9a00d3c9-bd2d-45b0-988b-6cff99ae2a90",
+                                            "permalink": "https://hitchhikers.slack.com/archives/C12345678/p1508795665000236",
+                                            "team": "T12345678",
+                                            "text": "The meaning of life the universe and everything is 101010",
+                                            "ts": "1508795665.000236",
+                                            "type": "message",
+                                            "user": "",
+                                            "username": "robot overlord"
+                                        }
+                                    ],
+                                    "pagination": {
+                                        "first": 1,
+                                        "last": 2,
+                                        "page": 1,
+                                        "page_count": 1,
+                                        "per_page": 20,
+                                        "total_count": 2
+                                    },
+                                    "paging": {
+                                        "count": 20,
+                                        "page": 1,
+                                        "pages": 1,
+                                        "total": 2
+                                    },
+                                    "total": 2
+                                },
+                                "ok": true,
+                                "query": "The meaning of life the universe and everything"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -18900,6 +21763,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "No query passed",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -18979,6 +21848,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.add method",
@@ -18996,6 +21870,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.add method",
@@ -19106,6 +21986,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.list method",
@@ -19280,6 +22165,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.list method",
@@ -19388,6 +22279,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from stars.remove method",
@@ -19405,6 +22301,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from stars.remove method",
@@ -19510,6 +22412,43 @@
                 "responses": {
                     "200": {
                         "description": "This response demonstrates pagination and two access log entries.",
+                        "examples": {
+                            "application/json": {
+                                "logins": [
+                                    {
+                                        "count": 1,
+                                        "country": "US",
+                                        "date_first": 1422922864,
+                                        "date_last": 1422922864,
+                                        "ip": "127.0.0.1",
+                                        "isp": "BigCo ISP",
+                                        "region": "CA",
+                                        "user_agent": "SlackWeb Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.35 Safari/537.36",
+                                        "user_id": "U45678",
+                                        "username": "alice"
+                                    },
+                                    {
+                                        "count": 1,
+                                        "country": "US",
+                                        "date_first": 1422922493,
+                                        "date_last": 1422922493,
+                                        "ip": "127.0.0.1",
+                                        "isp": "BigCo ISP",
+                                        "region": "CA",
+                                        "user_agent": "SlackWeb Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B466 Safari/600.1.4",
+                                        "user_id": "U12345",
+                                        "username": "white_rabbit"
+                                    }
+                                ],
+                                "ok": true,
+                                "paging": {
+                                    "count": 100,
+                                    "page": 1,
+                                    "pages": 1,
+                                    "total": 2
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.accessLogs method",
@@ -19597,6 +22536,12 @@
                     },
                     "default": {
                         "description": "A workspace must be on a paid plan to use this method, otherwise the `paid_only` error is thrown:",
+                        "examples": {
+                            "application/json": {
+                                "error": "paid_only",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.accessLogs method",
@@ -19688,6 +22633,22 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "billable_info": {
+                                    "U02UCPE1R": {
+                                        "billing_active": true
+                                    },
+                                    "U02UEBSD2": {
+                                        "billing_active": true
+                                    },
+                                    "U0632EWRW": {
+                                        "billing_active": false
+                                    }
+                                },
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -19705,6 +22666,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -19765,6 +22732,28 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "domain": "example",
+                                    "email_domain": "example.com",
+                                    "enterprise_id": "E1234A12AB",
+                                    "enterprise_name": "Umbrella Corporation",
+                                    "icon": {
+                                        "image_102": "https://...",
+                                        "image_132": "https://...",
+                                        "image_34": "https://...",
+                                        "image_44": "https://...",
+                                        "image_68": "https://...",
+                                        "image_88": "https://...",
+                                        "image_default": true
+                                    },
+                                    "id": "T12345",
+                                    "name": "My Team"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.info method",
@@ -19786,6 +22775,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.info method",
@@ -19901,6 +22896,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.integrationLogs method",
@@ -19976,6 +22976,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.integrationLogs method",
@@ -20065,6 +23071,77 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "fields": [
+                                        {
+                                            "hint": "Enter the extension to reach your desk",
+                                            "id": "Xf06054AAA",
+                                            "is_hidden": 1,
+                                            "label": "Phone extension",
+                                            "options": null,
+                                            "ordering": 0,
+                                            "possible_values": null,
+                                            "type": "text"
+                                        },
+                                        {
+                                            "hint": "When you were born",
+                                            "id": "Xf06054BBB",
+                                            "label": "Date of birth",
+                                            "options": null,
+                                            "ordering": 1,
+                                            "possible_values": null,
+                                            "type": "date"
+                                        },
+                                        {
+                                            "hint": "Enter a link to your Facebook profile",
+                                            "id": "Xf06054CCC",
+                                            "label": "Facebook",
+                                            "options": null,
+                                            "ordering": 2,
+                                            "possible_values": null,
+                                            "type": "link"
+                                        },
+                                        {
+                                            "hint": "Hogwarts, obviously",
+                                            "id": "Xf06054DDD",
+                                            "label": "House",
+                                            "options": null,
+                                            "ordering": 3,
+                                            "possible_values": [
+                                                "Gryffindor",
+                                                "Hufflepuff",
+                                                "Ravenclaw",
+                                                "Slytherin"
+                                            ],
+                                            "type": "options_list"
+                                        },
+                                        {
+                                            "hint": "Office location (LDAP)",
+                                            "id": "Xf06054EEE",
+                                            "label": "Location",
+                                            "options": {
+                                                "is_protected": 1
+                                            },
+                                            "ordering": 4,
+                                            "possible_values": null,
+                                            "type": "text"
+                                        },
+                                        {
+                                            "hint": "The boss",
+                                            "id": "Xf06054FFF",
+                                            "label": "Manager",
+                                            "options": null,
+                                            "ordering": 5,
+                                            "possible_values": null,
+                                            "type": "user"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from team.profile.get method",
@@ -20099,6 +23176,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from team.profile.get method",
@@ -20212,6 +23295,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.create method",
@@ -20233,6 +23321,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.create method",
@@ -20332,6 +23426,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.disable method",
@@ -20353,6 +23452,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.disable method",
@@ -20452,6 +23557,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.enable method",
@@ -20473,6 +23583,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.enable method",
@@ -20577,6 +23693,76 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroups": [
+                                    {
+                                        "auto_type": "admin",
+                                        "created_by": "USLACKBOT",
+                                        "date_create": 1446598059,
+                                        "date_delete": 0,
+                                        "date_update": 1446670362,
+                                        "deleted_by": null,
+                                        "description": "A group of all Administrators on your team.",
+                                        "handle": "admins",
+                                        "id": "S0614TZR7",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Team Admins",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "U060RNRCZ",
+                                        "user_count": "2"
+                                    },
+                                    {
+                                        "auto_type": "owner",
+                                        "created_by": "USLACKBOT",
+                                        "date_create": 1446678371,
+                                        "date_delete": 0,
+                                        "date_update": 1446678371,
+                                        "deleted_by": null,
+                                        "description": "A group of all Owners on your team.",
+                                        "handle": "owners",
+                                        "id": "S06158AV7",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Team Owners",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "USLACKBOT",
+                                        "user_count": "1"
+                                    },
+                                    {
+                                        "auto_type": null,
+                                        "created_by": "U060RNRCZ",
+                                        "date_create": 1446746793,
+                                        "date_delete": 1446748865,
+                                        "date_update": 1446747767,
+                                        "deleted_by": null,
+                                        "description": "Marketing gurus, PR experts and product advocates.",
+                                        "handle": "marketing-team",
+                                        "id": "S0615G0KT",
+                                        "is_external": false,
+                                        "is_usergroup": true,
+                                        "name": "Marketing Team",
+                                        "prefs": {
+                                            "channels": [],
+                                            "groups": []
+                                        },
+                                        "team_id": "T060RNRCH",
+                                        "updated_by": "U060RNRCZ",
+                                        "user_count": "0"
+                                    }
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.list method",
@@ -20601,6 +23787,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.list method",
@@ -20725,6 +23917,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroup": {
+                                    "auto_type": null,
+                                    "created_by": "U060R4BJ4",
+                                    "date_create": 1447096577,
+                                    "date_delete": 0,
+                                    "date_update": 1447102109,
+                                    "deleted_by": null,
+                                    "description": "Marketing gurus, PR experts and product advocates.",
+                                    "handle": "marketing-team",
+                                    "id": "S0616NG6M",
+                                    "is_external": false,
+                                    "is_usergroup": true,
+                                    "name": "Marketing Team",
+                                    "prefs": {
+                                        "channels": [],
+                                        "groups": []
+                                    },
+                                    "team_id": "T060R4BHN",
+                                    "updated_by": "U060R4BJ4",
+                                    "user_count": 1,
+                                    "users": [
+                                        "U060R4BJ4",
+                                        "U060RNRCZ"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.update method",
@@ -20746,6 +23968,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.update method",
@@ -20846,6 +24074,15 @@
                 "responses": {
                     "200": {
                         "description": "Standard success response when used with a user token",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "users": [
+                                    "U060R4BJ4",
+                                    "W123A4BC5"
+                                ]
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.users.list method",
@@ -20870,6 +24107,12 @@
                     },
                     "default": {
                         "description": "Standard failure response when used with an invalid token",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.users.list method",
@@ -20978,6 +24221,36 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "usergroup": {
+                                    "auto_type": null,
+                                    "created_by": "U060R4BJ4",
+                                    "date_create": 1447096577,
+                                    "date_delete": 0,
+                                    "date_update": 1447102109,
+                                    "deleted_by": null,
+                                    "description": "Marketing gurus, PR experts and product advocates.",
+                                    "handle": "marketing-team",
+                                    "id": "S0616NG6M",
+                                    "is_external": false,
+                                    "is_usergroup": true,
+                                    "name": "Marketing Team",
+                                    "prefs": {
+                                        "channels": [],
+                                        "groups": []
+                                    },
+                                    "team_id": "T060R4BHN",
+                                    "updated_by": "U060R4BJ4",
+                                    "user_count": 1,
+                                    "users": [
+                                        "U060R4BJ4",
+                                        "U060RNRCZ"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from usergroups.users.update method",
@@ -20999,6 +24272,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from usergroups.users.update method",
@@ -21116,6 +24395,78 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response with only public channels. Note how `num_members` and `is_member` are not returned like typical `conversations` objects.",
+                        "examples": {
+                            "application/json": {
+                                "channels": [
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U012A3CDE",
+                                        "id": "C012AB3CD",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": true,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "general",
+                                        "name_normalized": "general",
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "This channel is for team-wide communication and announcements. All team members are in this channel."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Company-wide announcements and work-based matters"
+                                        },
+                                        "unlinked": 0
+                                    },
+                                    {
+                                        "created": 1449252889,
+                                        "creator": "U061F7AUR",
+                                        "id": "C061EG9T2",
+                                        "is_archived": false,
+                                        "is_channel": true,
+                                        "is_ext_shared": false,
+                                        "is_general": false,
+                                        "is_group": false,
+                                        "is_im": false,
+                                        "is_mpim": false,
+                                        "is_org_shared": false,
+                                        "is_pending_ext_shared": false,
+                                        "is_private": false,
+                                        "is_shared": false,
+                                        "name": "random",
+                                        "name_normalized": "random",
+                                        "pending_shared": [],
+                                        "previous_names": [],
+                                        "purpose": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you'd prefer to keep out of more focused work-related channels."
+                                        },
+                                        "topic": {
+                                            "creator": "",
+                                            "last_set": 0,
+                                            "value": "Non-work banter and water cooler conversation"
+                                        },
+                                        "unlinked": 0
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dGVhbTpDMDYxRkE1UEI="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.conversations method. Returned conversation objects do not include `num_members` or `is_member`",
@@ -21153,6 +24504,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.conversations method",
@@ -21242,6 +24599,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.deletePhoto method",
@@ -21259,6 +24621,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.deletePhoto method",
@@ -21348,6 +24716,12 @@
                 "responses": {
                     "200": {
                         "description": "When requesting information for a different user, this method just returns the current presence (either `active` or `away`).",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "presence": "active"
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Generated from users.getPresence with shasum e7251aec575d8863f9e0eb38663ae9dc26655f65",
@@ -21384,6 +24758,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": {
                                 "type": "object"
@@ -21443,6 +24823,18 @@
                 "responses": {
                     "200": {
                         "description": "You will receive at a minimum the following information:",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "team": {
+                                    "id": "T0G9PQBBK"
+                                },
+                                "user": {
+                                    "id": "U0G9QF9C6",
+                                    "name": "Sonny Whether"
+                                }
+                            }
+                        },
                         "schema": {
                             "description": "Schema for successful response from users.identity method",
                             "items": [
@@ -21706,6 +25098,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "account_inactive",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.identity method",
@@ -21801,6 +25199,49 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "user": {
+                                    "color": "9f69e7",
+                                    "deleted": false,
+                                    "has_2fa": false,
+                                    "id": "W012A3CDE",
+                                    "is_admin": true,
+                                    "is_app_user": false,
+                                    "is_bot": false,
+                                    "is_owner": false,
+                                    "is_primary_owner": false,
+                                    "is_restricted": false,
+                                    "is_ultra_restricted": false,
+                                    "name": "spengler",
+                                    "profile": {
+                                        "avatar_hash": "ge3b51ca72de",
+                                        "display_name": "spengler",
+                                        "display_name_normalized": "spengler",
+                                        "email": "spengler@ghostbusters.example.com",
+                                        "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "real_name": "Egon Spengler",
+                                        "real_name_normalized": "Egon Spengler",
+                                        "status_emoji": ":books:",
+                                        "status_text": "Print is dead",
+                                        "team": "T012AB3C4"
+                                    },
+                                    "real_name": "Egon Spengler",
+                                    "team_id": "T012AB3C4",
+                                    "tz": "America/Los_Angeles",
+                                    "tz_label": "Pacific Daylight Time",
+                                    "tz_offset": -25200,
+                                    "updated": 1502138686
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.info method",
@@ -21822,6 +25263,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.info method",
@@ -21918,6 +25365,94 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "cache_ts": 1498777272,
+                                "members": [
+                                    {
+                                        "color": "9f69e7",
+                                        "deleted": false,
+                                        "has_2fa": false,
+                                        "id": "W012A3CDE",
+                                        "is_admin": true,
+                                        "is_app_user": false,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false,
+                                        "name": "spengler",
+                                        "profile": {
+                                            "avatar_hash": "ge3b51ca72de",
+                                            "display_name": "spengler",
+                                            "display_name_normalized": "spengler",
+                                            "email": "spengler@ghostbusters.example.com",
+                                            "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                            "real_name": "Egon Spengler",
+                                            "real_name_normalized": "Egon Spengler",
+                                            "status_emoji": ":books:",
+                                            "status_text": "Print is dead",
+                                            "team": "T012AB3C4"
+                                        },
+                                        "real_name": "spengler",
+                                        "team_id": "T012AB3C4",
+                                        "tz": "America/Los_Angeles",
+                                        "tz_label": "Pacific Daylight Time",
+                                        "tz_offset": -25200,
+                                        "updated": 1502138686
+                                    },
+                                    {
+                                        "color": "9f69e7",
+                                        "deleted": false,
+                                        "has_2fa": false,
+                                        "id": "W07QCRPA4",
+                                        "is_admin": true,
+                                        "is_bot": false,
+                                        "is_owner": false,
+                                        "is_primary_owner": false,
+                                        "is_restricted": false,
+                                        "is_ultra_restricted": false,
+                                        "name": "glinda",
+                                        "profile": {
+                                            "avatar_hash": "8fbdd10b41c6",
+                                            "display_name": "Glinda the Fairly Good",
+                                            "display_name_normalized": "Glinda the Fairly Good",
+                                            "email": "glenda@south.oz.coven",
+                                            "first_name": "Glinda",
+                                            "image_1024": "https://a.slack-edge.com...png",
+                                            "image_192": "https://a.slack-edge.com...png",
+                                            "image_24": "https://a.slack-edge.com...png",
+                                            "image_32": "https://a.slack-edge.com...png",
+                                            "image_48": "https://a.slack-edge.com...png",
+                                            "image_512": "https://a.slack-edge.com...png",
+                                            "image_72": "https://a.slack-edge.com...png",
+                                            "image_original": "https://a.slack-edge.com...png",
+                                            "last_name": "Southgood",
+                                            "phone": "",
+                                            "real_name": "Glinda Southgood",
+                                            "real_name_normalized": "Glinda Southgood",
+                                            "skype": "",
+                                            "title": "Glinda the Good"
+                                        },
+                                        "real_name": "Glinda Southgood",
+                                        "team_id": "T0G9PQBBK",
+                                        "tz": "America/Los_Angeles",
+                                        "tz_label": "Pacific Daylight Time",
+                                        "tz_offset": -25200,
+                                        "updated": 1480527098
+                                    }
+                                ],
+                                "ok": true,
+                                "response_metadata": {
+                                    "next_cursor": "dXNlcjpVMEc5V0ZYTlo="
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.list method",
@@ -21951,6 +25486,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_cursor",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.list method",
@@ -22040,6 +25581,48 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "user": {
+                                    "color": "9f69e7",
+                                    "deleted": false,
+                                    "has_2fa": false,
+                                    "id": "W012A3CDE",
+                                    "is_admin": true,
+                                    "is_app_user": false,
+                                    "is_bot": false,
+                                    "is_owner": false,
+                                    "is_primary_owner": false,
+                                    "is_restricted": false,
+                                    "is_ultra_restricted": false,
+                                    "name": "spengler",
+                                    "profile": {
+                                        "avatar_hash": "ge3b51ca72de",
+                                        "display_name": "spengler",
+                                        "display_name_normalized": "spengler",
+                                        "email": "spengler@ghostbusters.example.com",
+                                        "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                        "real_name": "Egon Spengler",
+                                        "real_name_normalized": "Egon Spengler",
+                                        "status_emoji": ":books:",
+                                        "status_text": "Print is dead",
+                                        "team": "T012AB3C4"
+                                    },
+                                    "real_name": "Egon Spengler",
+                                    "team_id": "T012AB3C4",
+                                    "tz": "America/Los_Angeles",
+                                    "tz_label": "Pacific Daylight Time",
+                                    "tz_offset": -25200,
+                                    "updated": 1502138686
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "Schema for successful response from users.lookupByEmail method",
@@ -22061,6 +25644,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "users_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.lookupByEmail method",
@@ -22155,6 +25744,30 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "avatar_hash": "ge3b51ca72de",
+                                    "display_name": "spengler",
+                                    "display_name_normalized": "spengler",
+                                    "email": "spengler@ghostbusters.example.com",
+                                    "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "real_name": "Egon Spengler",
+                                    "real_name_normalized": "Egon Spengler",
+                                    "status_emoji": ":books:",
+                                    "status_expiration": 0,
+                                    "status_text": "Print is dead",
+                                    "team": "T012AB3C4"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.profile.get method",
@@ -22176,6 +25789,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "user_not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.profile.get method",
@@ -22286,6 +25905,29 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "profile": {
+                                    "avatar_hash": "ge3b51ca72de",
+                                    "display_name": "spengler",
+                                    "display_name_normalized": "spengler",
+                                    "email": "spengler@ghostbusters.example.com",
+                                    "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                                    "real_name": "Egon Spengler",
+                                    "real_name_normalized": "Egon Spengler",
+                                    "status_emoji": ":books:",
+                                    "status_expiration": 0,
+                                    "status_text": "Print is dead",
+                                    "team": "T012AB3C4"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.profile.set method",
@@ -22315,6 +25957,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_profile",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.profile.set method",
@@ -22406,6 +26054,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setActive method",
@@ -22423,6 +26076,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setActive method",
@@ -22529,6 +26188,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setPhoto method",
@@ -22600,6 +26264,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setPhoto method",
@@ -22707,6 +26377,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for successful response from users.setPresence method",
@@ -22724,6 +26399,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": false,
                             "description": "Schema for error response from users.setPresence method",
@@ -22822,6 +26503,52 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the opened view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AA4928AQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "a_block_id",
+                                            "element": {
+                                                "action_id": "an_action_id",
+                                                "type": "plain_text_input"
+                                            },
+                                            "label": {
+                                                "emoji": true,
+                                                "text": "A simple label",
+                                                "type": "plain_text"
+                                            },
+                                            "optional": false,
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "bot_id": "BA13894H",
+                                    "callback_id": "identify_your_modals",
+                                    "clear_on_close": false,
+                                    "external_id": "",
+                                    "hash": "156772938.1827394",
+                                    "id": "VMHU10V25",
+                                    "notify_on_close": false,
+                                    "private_metadata": "Shh it is a secret",
+                                    "root_view_id": "VMHU10V25",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": {
+                                        "text": "Create",
+                                        "type": "plain_text"
+                                    },
+                                    "team_id": "T8N4K1JN",
+                                    "title": {
+                                        "text": "Quite a plain modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22839,6 +26566,17 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "invalid `trigger_id`"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -22914,6 +26652,42 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the published view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AA4928AQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "2WGp9",
+                                            "text": {
+                                                "text": "A simple section with some sample sentence.",
+                                                "type": "mrkdwn",
+                                                "verbatim": false
+                                            },
+                                            "type": "section"
+                                        }
+                                    ],
+                                    "bot_id": "BA13894H",
+                                    "callback_id": "identify_your_home_tab",
+                                    "clear_on_close": false,
+                                    "close": null,
+                                    "external_id": "",
+                                    "hash": "156772938.1827394",
+                                    "id": "VMHU10V25",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "Shh it is a secret",
+                                    "root_view_id": "VMHU10V25",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": null,
+                                    "team_id": "T8N4K1JN",
+                                    "type": "home"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -22931,6 +26705,17 @@
                     },
                     "default": {
                         "description": "Typical error response, before getting to any possible validation errors.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "invalid `user_id`"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -23000,6 +26785,58 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the pushed view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AAD3351BQ",
+                                    "blocks": [
+                                        {
+                                            "block_id": "edit_details",
+                                            "element": {
+                                                "action_id": "detail_input",
+                                                "type": "plain_text_input"
+                                            },
+                                            "label": {
+                                                "text": "Edit details",
+                                                "type": "plain_text"
+                                            },
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "bot_id": "BADF7A34H",
+                                    "callback_id": "view_4",
+                                    "clear_on_close": true,
+                                    "close": {
+                                        "emoji": true,
+                                        "text": "Back",
+                                        "type": "plain_text"
+                                    },
+                                    "external_id": "",
+                                    "hash": "1569362015.55b5e41b",
+                                    "id": "VNM522E2U",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "",
+                                    "root_view_id": "VNN729E3U",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": {
+                                        "emoji": true,
+                                        "text": "Save",
+                                        "type": "plain_text"
+                                    },
+                                    "team_id": "T9M4RL1JM",
+                                    "title": {
+                                        "emoji": true,
+                                        "text": "Pushed Modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -23017,6 +26854,17 @@
                     },
                     "default": {
                         "description": "Typical error response.",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_arguments",
+                                "ok": false,
+                                "response_metadata": {
+                                    "messages": [
+                                        "missing required field: title"
+                                    ]
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -23096,6 +26944,59 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response includes the updated view payload.",
+                        "examples": {
+                            "application/json": {
+                                "ok": true,
+                                "view": {
+                                    "app_id": "AAD3351BQ",
+                                    "blocks": [
+                                        {
+                                            "accessory": {
+                                                "action_id": "button_4",
+                                                "text": {
+                                                    "text": "Click me",
+                                                    "type": "plain_text"
+                                                },
+                                                "type": "button"
+                                            },
+                                            "block_id": "s_block",
+                                            "text": {
+                                                "emoji": true,
+                                                "text": "I am but an updated modal",
+                                                "type": "plain_text"
+                                            },
+                                            "type": "section"
+                                        }
+                                    ],
+                                    "bot_id": "BADF7A34H",
+                                    "callback_id": "view_2",
+                                    "clear_on_close": true,
+                                    "close": {
+                                        "emoji": true,
+                                        "text": "Close",
+                                        "type": "plain_text"
+                                    },
+                                    "external_id": "",
+                                    "hash": "1569262015.55b5e41b",
+                                    "id": "VNM522E2U",
+                                    "notify_on_close": false,
+                                    "previous_view_id": null,
+                                    "private_metadata": "",
+                                    "root_view_id": "VNN729E3U",
+                                    "state": {
+                                        "values": {}
+                                    },
+                                    "submit": null,
+                                    "team_id": "T9M4RL1JM",
+                                    "title": {
+                                        "emoji": true,
+                                        "text": "Updated Modal",
+                                        "type": "plain_text"
+                                    },
+                                    "type": "modal"
+                                }
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -23113,6 +27014,12 @@
                     },
                     "default": {
                         "description": "Typical error response.",
+                        "examples": {
+                            "application/json": {
+                                "error": "not_found",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -23181,6 +27088,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -23198,6 +27110,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -23267,6 +27185,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -23284,6 +27207,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",
@@ -23370,6 +27299,11 @@
                 "responses": {
                     "200": {
                         "description": "Typical success response",
+                        "examples": {
+                            "application/json": {
+                                "ok": true
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _OK_ response or a verbose schema is not available for this method.",
@@ -23387,6 +27321,12 @@
                     },
                     "default": {
                         "description": "Typical error response",
+                        "examples": {
+                            "application/json": {
+                                "error": "invalid_auth",
+                                "ok": false
+                            }
+                        },
                         "schema": {
                             "additionalProperties": true,
                             "description": "This method either only returns a brief _not OK_ response or a verbose schema is not available for this method.",

--- a/src/Checker/SchemaChecker.php
+++ b/src/Checker/SchemaChecker.php
@@ -45,8 +45,10 @@ class SchemaChecker
                     if (empty($responseConfig->examples) || empty($responseConfig->examples->{'application/json'})) {
                         $summary[$path][$method][$response] = [
                             'errors' => [
-                                'path' => '',
-                                'error' => 'No example given',
+                                [
+                                    'property' => '',
+                                    'error' => 'No example given',
+                                ],
                             ],
                         ];
 

--- a/src/Command/UpdateSpecificationCommand.php
+++ b/src/Command/UpdateSpecificationCommand.php
@@ -37,8 +37,8 @@ class UpdateSpecificationCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        // download official Slack OpenAPI spec and save it
-        $content = HttpClient::create()->request('GET', 'https://api.slack.com/specs/openapi/v2/slack_web.json', [
+        // download official Slack OpenAPI spec and save it (use github version to have response specs with examples)
+        $content = HttpClient::create()->request('GET', 'https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json', [
             'headers' => [
                 'Accept' => 'application/json',
             ],


### PR DESCRIPTION
Slack server only provides an OpenAPI spec without examples, making the `bin/slack-api-client-generator checker` command quite useless.

We now used the correct json from their github instead which contains the full spec.