### PR TITLE
Refactor and fix tests when no env vars given

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,25 @@ jobs:
               with:
                   args: --config=.php_cs --diff --dry-run
 
+    check-spec:
+        name: Check SDK is in sync with spec
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Install dependencies
+              run: composer update --prefer-dist --no-interaction
+
+            - name: Generate SDK in ci_generated directory
+              run: CI_TEST=1 vendor/bin/jane-openapi generate --config-file=.jane-openapi.php
+
+            - name: Fix CS on ci_generated directory
+              run: vendor/bin/php-cs-fixer fix --diff --dry-run ci_generated
+
+            - name: Check ci_generated and generated directories are equal
+              run: diff ci_generated generated
+
     tests:
         name: Test PHP ${{ matrix.php-version }} ${{ matrix.name }}
         runs-on: ubuntu-latest
@@ -43,19 +62,8 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   extensions: mbstring, xml
 
-            - name: Get composer cache directory
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            - name: Cache composer dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ github.sha }}
-                  restore-keys: ${{ runner.os }}-composer-
-
             - name: Install dependencies
-              run: composer update --prefer-dist --no-interaction ${{ matrix.composer-flags }}
+              run: "composer update --prefer-dist --no-interaction ${{ matrix.composer-flags }}"
 
             - name: Run tests
               run: php vendor/bin/simple-phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ composer.phar
 phpunit.xml
 
 # tests
-generated_ci
+ci_generated
 .phpunit.result.cache

--- a/.jane-openapi.php
+++ b/.jane-openapi.php
@@ -3,7 +3,7 @@
 $directory = __DIR__ . '/generated/';
 
 if (!empty($_SERVER['CI_TEST'])) {
-    $directory = __DIR__ . '/generated_ci/';
+    $directory = __DIR__ . '/ci_generated/';
 }
 
 return [

--- a/.php_cs
+++ b/.php_cs
@@ -34,9 +34,9 @@ return PhpCsFixer\Config::create()
         'semicolon_after_instruction' => true,
         'combine_consecutive_unsets' => true,
     ))
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->in(__DIR__)
-            ->exclude('doc')
+    ->setFinder(PhpCsFixer\Finder::create()
+        ->in(__DIR__)
+        ->exclude('doc')
+        ->exclude('ci_generated')
     )
 ;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of JoliCode's Slack PHP API project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\Slack\Tests;
+
+use JoliCode\Slack\Api\Model\ApiTestGetResponse200;
+use JoliCode\Slack\ClientFactory;
+use JoliCode\Slack\Exception\SlackErrorResponse;
+use PHPUnit\Framework\TestCase;
+
+class ApiTest extends TestCase
+{
+    public function testItWorksOnTestSuccess()
+    {
+        $client = ClientFactory::create('');
+        $response = $client->apiTest();
+
+        self::assertInstanceOf(ApiTestGetResponse200::class, $response);
+        self::assertTrue($response->getOk());
+    }
+
+    public function testItThrowsExceptionOnTestError()
+    {
+        $client = ClientFactory::create('');
+
+        self::expectException(SlackErrorResponse::class);
+        self::expectExceptionMessage('Slack returned error code "yolo"');
+
+        $client->apiTest([
+            'error' => 'yolo',
+        ]);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -14,21 +14,12 @@ declare(strict_types=1);
 namespace JoliCode\Slack\Tests;
 
 use JoliCode\Slack\Api\Model\ObjsUser;
-use JoliCode\Slack\ClientFactory;
-use PHPUnit\Framework\TestCase;
 
-class ClientTest extends TestCase
+class ClientTest extends SlackTokenDependentTest
 {
-    protected function setUp(): void
-    {
-        if (!\array_key_exists('SLACK_TOKEN', $_SERVER)) {
-            $this->markTestSkipped('SLACK_TOKEN env var not present, skip the test.');
-        }
-    }
-
     public function testItCanIterate()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $users = $client->iterateUsersList([
             'limit' => 1000,
@@ -44,7 +35,7 @@ class ClientTest extends TestCase
 
     public function testItThrowsExceptionOnUnknownIterate()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         self::expectException(\BadMethodCallException::class);
         self::expectExceptionMessage('Unknown method JoliCode\Slack\Client::iterateFooBar()');
@@ -54,7 +45,7 @@ class ClientTest extends TestCase
 
     public function testItThrowsExceptionOnUnknownMethod()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         self::expectException(\BadMethodCallException::class);
         self::expectExceptionMessage('Unknown method JoliCode\Slack\Client::foobar()');

--- a/tests/ReadingTest.php
+++ b/tests/ReadingTest.php
@@ -13,49 +13,18 @@ declare(strict_types=1);
 
 namespace JoliCode\Slack\Tests;
 
-use JoliCode\Slack\Api\Model\ApiTestGetResponse200;
 use JoliCode\Slack\Api\Model\ConversationsHistoryGetResponse200;
 use JoliCode\Slack\Api\Model\ConversationsListGetResponse200;
 use JoliCode\Slack\Api\Model\ObjsFile;
 use JoliCode\Slack\Api\Model\SearchMessagesGetResponse200;
 use JoliCode\Slack\Api\Model\UsersListGetResponse200;
-use JoliCode\Slack\ClientFactory;
 use JoliCode\Slack\Exception\SlackErrorResponse;
-use PHPUnit\Framework\TestCase;
 
-class ReadingTest extends TestCase
+class ReadingTest extends SlackTokenDependentTest
 {
-    protected function setUp(): void
-    {
-        if (!\array_key_exists('SLACK_TOKEN', $_SERVER)) {
-            $this->markTestSkipped('SLACK_TOKEN env var not present, skip the test.');
-        }
-    }
-
-    public function testItWorksOnTestSuccess()
-    {
-        $client = ClientFactory::create('');
-        $response = $client->apiTest();
-
-        self::assertInstanceOf(ApiTestGetResponse200::class, $response);
-        self::assertTrue($response->getOk());
-    }
-
-    public function testItThrowsExceptionOnTestError()
-    {
-        $client = ClientFactory::create('');
-
-        self::expectException(SlackErrorResponse::class);
-        self::expectExceptionMessage('Slack returned error code "yolo"');
-
-        $client->apiTest([
-            'error' => 'yolo',
-        ]);
-    }
-
     public function testItWorksOnUserListWithCorrectToken()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $response = $client->usersList();
 
@@ -67,7 +36,7 @@ class ReadingTest extends TestCase
 
     public function testItThrowsExceptionOnUserListWithoutToken()
     {
-        $client = ClientFactory::create('');
+        $client = $this->createClient('');
 
         self::expectException(SlackErrorResponse::class);
         self::expectExceptionMessage('Slack returned error code "not_authed"');
@@ -77,7 +46,7 @@ class ReadingTest extends TestCase
 
     public function testItCanReadAConversationHistory()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $results = $client->conversationsHistory([
             'channel' => $_SERVER['SLACK_TEST_CHANNEL'],
@@ -105,7 +74,7 @@ class ReadingTest extends TestCase
 
     public function testItCanGetTheImList()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $results = $client->conversationsList(['types' => 'im']);
 
@@ -115,7 +84,7 @@ class ReadingTest extends TestCase
 
     public function testItCanReadConversationsAndHydrateThem()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         /** @var ConversationsListGetResponse200 $response */
         $response = $client->conversationsList([
@@ -133,7 +102,7 @@ class ReadingTest extends TestCase
 
     public function testItCanSearchMessages()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         /** @var SearchMessagesGetResponse200 $results */
         $results = $client->searchMessages([

--- a/tests/SlackTokenDependentTest.php
+++ b/tests/SlackTokenDependentTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of JoliCode's Slack PHP API project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\Slack\Tests;
+
+use JoliCode\Slack\Client;
+use JoliCode\Slack\ClientFactory;
+use PHPUnit\Framework\TestCase;
+
+abstract class SlackTokenDependentTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!($_SERVER['SLACK_TOKEN'] ?? null)) {
+            $this->markTestSkipped('SLACK_TOKEN env var not present, skip the test.');
+        }
+    }
+
+    protected function createClient(?string $token = null): Client
+    {
+        return ClientFactory::create(null === $token ? $_SERVER['SLACK_TOKEN'] : $token);
+    }
+}

--- a/tests/UserInfoTest.php
+++ b/tests/UserInfoTest.php
@@ -14,21 +14,12 @@ declare(strict_types=1);
 namespace JoliCode\Slack\Tests;
 
 use JoliCode\Slack\Api\Model\UsersListGetResponse200;
-use JoliCode\Slack\ClientFactory;
-use PHPUnit\Framework\TestCase;
 
-class UserInfoTest extends TestCase
+class UserInfoTest extends SlackTokenDependentTest
 {
-    protected function setUp(): void
-    {
-        if (!\array_key_exists('SLACK_TOKEN', $_SERVER)) {
-            $this->markTestSkipped('SLACK_TOKEN env var not present, skip the test.');
-        }
-    }
-
     public function testItCanFetchUserInfo()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $response = $client->usersList(['limit' => 2]);
 

--- a/tests/WritingTest.php
+++ b/tests/WritingTest.php
@@ -15,22 +15,13 @@ namespace JoliCode\Slack\Tests;
 
 use JoliCode\Slack\Api\Model\ChatPostMessagePostResponse200;
 use JoliCode\Slack\Api\Model\FilesUploadPostResponse200;
-use JoliCode\Slack\ClientFactory;
 use Nyholm\Psr7\Stream;
-use PHPUnit\Framework\TestCase;
 
-class WritingTest extends TestCase
+class WritingTest extends SlackTokenDependentTest
 {
-    protected function setUp(): void
-    {
-        if (!\array_key_exists('SLACK_TOKEN', $_SERVER)) {
-            $this->markTestSkipped('SLACK_TOKEN env var not present, skip the test.');
-        }
-    }
-
     public function testItCanPostAttachment()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $response = $client->chatPostMessage([
             'username' => 'User A',
@@ -53,7 +44,7 @@ class WritingTest extends TestCase
 
     public function testItCanPostMessageWithBlock()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $response = $client->chatPostMessage([
             'username' => 'User C',
@@ -88,7 +79,7 @@ class WritingTest extends TestCase
 
     public function testItCanPostAMessageAndThenAThreadResponse()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         /** @var ChatPostMessagePostResponse200 $response */
         $response = $client->chatPostMessage([
@@ -109,7 +100,7 @@ class WritingTest extends TestCase
 
     public function testItCanUploadFile()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         /** @var FilesUploadPostResponse200 $response */
         $response = $client->filesUpload([
@@ -133,7 +124,7 @@ class WritingTest extends TestCase
 
     public function testScheduleMessage()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
         $futureTs = (new \DateTime('+1 hour'))->getTimestamp();
 
         $response = $client->chatScheduleMessage([
@@ -147,7 +138,7 @@ class WritingTest extends TestCase
 
     public function testItCanMarkConversation()
     {
-        $client = ClientFactory::create($_SERVER['SLACK_TOKEN']);
+        $client = $this->createClient();
 
         $response = $client->chatPostMessage([
             'username' => 'User A',


### PR DESCRIPTION
- Fix test skip check for when SLACK_TOKEN env var is not there
- Introduced abstract SlackTokenDependendTest to centralize logic for test that should be skipped when no token available
- Reintroduce CI job to ensure SDK is in sync with the spec