### PR TITLE
Fix: Update views API from GET to POST

### DIFF
--- a/generated/Endpoint/ViewsOpen.php
+++ b/generated/Endpoint/ViewsOpen.php
@@ -20,7 +20,7 @@ class ViewsOpen extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
     /**
      * Open a view for a user.
      *
-     * @param array $queryParameters {
+     * @param array $formParameters {
      *
      *     @var string $trigger_id exchange a trigger to post to the user
      *     @var string $view A [view payload](/reference/surfaces/views). This must be a JSON-encoded string.
@@ -31,15 +31,15 @@ class ViewsOpen extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
      *     @var string $token Authentication token. Requires scope: `none`
      * }
      */
-    public function __construct(array $queryParameters = [], array $headerParameters = [])
+    public function __construct(array $formParameters = [], array $headerParameters = [])
     {
-        $this->queryParameters = $queryParameters;
+        $this->formParameters = $formParameters;
         $this->headerParameters = $headerParameters;
     }
 
     public function getMethod(): string
     {
-        return 'GET';
+        return 'POST';
     }
 
     public function getUri(): string
@@ -49,7 +49,7 @@ class ViewsOpen extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
-        return [[], null];
+        return $this->getFormBody();
     }
 
     public function getExtraHeaders(): array
@@ -62,9 +62,9 @@ class ViewsOpen extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
         return ['slackAuth'];
     }
 
-    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
-        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver = parent::getFormOptionsResolver();
         $optionsResolver->setDefined(['trigger_id', 'view']);
         $optionsResolver->setRequired(['trigger_id', 'view']);
         $optionsResolver->setDefaults([]);

--- a/generated/Endpoint/ViewsPublish.php
+++ b/generated/Endpoint/ViewsPublish.php
@@ -20,7 +20,7 @@ class ViewsPublish extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint imple
     /**
      * Publish a static view for a User.
      *
-     * @param array $queryParameters {
+     * @param array $formParameters {
      *
      *     @var string $hash a string that represents view state to protect against possible race conditions
      *     @var string $user_id `id` of the user you want publish a view to
@@ -32,15 +32,15 @@ class ViewsPublish extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint imple
      *     @var string $token Authentication token. Requires scope: `none`
      * }
      */
-    public function __construct(array $queryParameters = [], array $headerParameters = [])
+    public function __construct(array $formParameters = [], array $headerParameters = [])
     {
-        $this->queryParameters = $queryParameters;
+        $this->formParameters = $formParameters;
         $this->headerParameters = $headerParameters;
     }
 
     public function getMethod(): string
     {
-        return 'GET';
+        return 'POST';
     }
 
     public function getUri(): string
@@ -50,7 +50,7 @@ class ViewsPublish extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint imple
 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
-        return [[], null];
+        return $this->getFormBody();
     }
 
     public function getExtraHeaders(): array
@@ -63,15 +63,15 @@ class ViewsPublish extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint imple
         return ['slackAuth'];
     }
 
-    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
-        $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(['hash', 'user_id', 'view']);
+        $optionsResolver = parent::getFormOptionsResolver();
+        $optionsResolver->setDefined(['user_id', 'view', 'hash']);
         $optionsResolver->setRequired(['user_id', 'view']);
         $optionsResolver->setDefaults([]);
-        $optionsResolver->setAllowedTypes('hash', ['string']);
         $optionsResolver->setAllowedTypes('user_id', ['string']);
         $optionsResolver->setAllowedTypes('view', ['string']);
+        $optionsResolver->setAllowedTypes('hash', ['string']);
 
         return $optionsResolver;
     }

--- a/generated/Endpoint/ViewsPush.php
+++ b/generated/Endpoint/ViewsPush.php
@@ -20,7 +20,7 @@ class ViewsPush extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
     /**
      * Push a view onto the stack of a root view.
      *
-     * @param array $queryParameters {
+     * @param array $formParameters {
      *
      *     @var string $trigger_id exchange a trigger to post to the user
      *     @var string $view A [view payload](/reference/surfaces/views). This must be a JSON-encoded string.
@@ -31,15 +31,15 @@ class ViewsPush extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
      *     @var string $token Authentication token. Requires scope: `none`
      * }
      */
-    public function __construct(array $queryParameters = [], array $headerParameters = [])
+    public function __construct(array $formParameters = [], array $headerParameters = [])
     {
-        $this->queryParameters = $queryParameters;
+        $this->formParameters = $formParameters;
         $this->headerParameters = $headerParameters;
     }
 
     public function getMethod(): string
     {
-        return 'GET';
+        return 'POST';
     }
 
     public function getUri(): string
@@ -49,7 +49,7 @@ class ViewsPush extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
-        return [[], null];
+        return $this->getFormBody();
     }
 
     public function getExtraHeaders(): array
@@ -62,9 +62,9 @@ class ViewsPush extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implemen
         return ['slackAuth'];
     }
 
-    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
-        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver = parent::getFormOptionsResolver();
         $optionsResolver->setDefined(['trigger_id', 'view']);
         $optionsResolver->setRequired(['trigger_id', 'view']);
         $optionsResolver->setDefaults([]);

--- a/generated/Endpoint/ViewsUpdate.php
+++ b/generated/Endpoint/ViewsUpdate.php
@@ -20,7 +20,7 @@ class ViewsUpdate extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implem
     /**
      * Update an existing view.
      *
-     * @param array $queryParameters {
+     * @param array $formParameters {
      *
      *     @var string $external_id A unique identifier of the view set by the developer. Must be unique for all views on a team. Max length of 255 characters. Either `view_id` or `external_id` is required.
      *     @var string $hash a string that represents view state to protect against possible race conditions
@@ -33,15 +33,15 @@ class ViewsUpdate extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implem
      *     @var string $token Authentication token. Requires scope: `none`
      * }
      */
-    public function __construct(array $queryParameters = [], array $headerParameters = [])
+    public function __construct(array $formParameters = [], array $headerParameters = [])
     {
-        $this->queryParameters = $queryParameters;
+        $this->formParameters = $formParameters;
         $this->headerParameters = $headerParameters;
     }
 
     public function getMethod(): string
     {
-        return 'GET';
+        return 'POST';
     }
 
     public function getUri(): string
@@ -51,7 +51,7 @@ class ViewsUpdate extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implem
 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
-        return [[], null];
+        return $this->getFormBody();
     }
 
     public function getExtraHeaders(): array
@@ -64,15 +64,15 @@ class ViewsUpdate extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implem
         return ['slackAuth'];
     }
 
-    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    protected function getFormOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
-        $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(['external_id', 'hash', 'view', 'view_id']);
-        $optionsResolver->setRequired([]);
+        $optionsResolver = parent::getFormOptionsResolver();
+        $optionsResolver->setDefined(['view', 'external_id', 'hash', 'view_id']);
+        $optionsResolver->setRequired(['view']);
         $optionsResolver->setDefaults([]);
+        $optionsResolver->setAllowedTypes('view', ['string']);
         $optionsResolver->setAllowedTypes('external_id', ['string']);
         $optionsResolver->setAllowedTypes('hash', ['string']);
-        $optionsResolver->setAllowedTypes('view', ['string']);
         $optionsResolver->setAllowedTypes('view_id', ['string']);
 
         return $optionsResolver;


### PR DESCRIPTION
All API about view have been change from GET method to POST method, references:
- [/views.open](https://api.slack.com/methods/views.open)
- [/views.publish](https://api.slack.com/methods/views.publish)
- [/views.push](https://api.slack.com/methods/views.push)
- [/views.update](https://api.slack.com/methods/views.update)