### PR TITLE
fix: 🐛 Don't use deprecated factory method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "jane-php/open-api-runtime": "~7.1",
         "psr/http-client-implementation": "*",
         "php-http/client-common": "^1.9 || ^2.0",
-        "php-http/discovery": "^1.7",
+        "php-http/discovery": "^1.11",
         "php-http/multipart-stream-builder": "^1.1"
     },
     "require-dev": {

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -32,7 +32,7 @@ class ClientFactory
         }
 
         // Decorates the HTTP client with some plugins
-        $uri = Psr17FactoryDiscovery::findUrlFactory()->createUri('https://slack.com/api');
+        $uri = Psr17FactoryDiscovery::findUriFactory()->createUri('https://slack.com/api');
         $pluginClient = new PluginClient($httpClient, [
             new ErrorPlugin(),
             new SlackErrorPlugin(),


### PR DESCRIPTION
Since `php-http/discovery:1.11`:
https://github.com/php-http/discovery/commit/be351ee2f4d68bb53e170813c6418fd5f959a8aa

✅ Closes: #138