### PR TITLE
fix: php 8.2 deprecation on problematic classes

### DIFF
--- a/generated/Endpoint/ChatPostMessage.php
+++ b/generated/Endpoint/ChatPostMessage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace JoliCode\Slack\Api\Endpoint;
 
+#[\AllowDynamicProperties]
 class ChatPostMessage extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implements \JoliCode\Slack\Api\Runtime\Client\Endpoint
 {
     use \JoliCode\Slack\Api\Runtime\Client\EndpointTrait;

--- a/generated/Endpoint/ConversationsOpen.php
+++ b/generated/Endpoint/ConversationsOpen.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace JoliCode\Slack\Api\Endpoint;
 
+#[\AllowDynamicProperties]
 class ConversationsOpen extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implements \JoliCode\Slack\Api\Runtime\Client\Endpoint
 {
     use \JoliCode\Slack\Api\Runtime\Client\EndpointTrait;


### PR DESCRIPTION
Explicitly allow dynamic properties on problematic classes to avoid deprecation warnings