### PR TITLE
Add denormalize hints

### DIFF
--- a/generated/Normalizer/AdminAppsApprovePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminAppsApprovePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsApprovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsApprovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminAppsApprovePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsApprovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsApprovedListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminAppsApprovedListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsApprovedListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsApprovedListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminAppsApprovedListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsApprovedListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsRequestsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminAppsRequestsListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsRequestsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsRequestsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminAppsRequestsListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsRequestsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsRestrictPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminAppsRestrictPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsRestrictPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsRestrictPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminAppsRestrictPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsRestrictPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsRestrictedListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminAppsRestrictedListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsRestrictedListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminAppsRestrictedListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminAppsRestrictedListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminAppsRestrictedListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsArchivePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsArchivePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsArchivePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsArchivePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsArchivePostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsArchivePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsConvertToPrivatePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsConvertToPrivatePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsConvertToPrivatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsConvertToPrivatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsConvertToPrivatePostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsConvertToPrivatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsCreatePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsCreatePostResponse200Normalizer.php
@@ -102,7 +102,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsCreatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsCreatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsCreatePostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsCreatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsDeletePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsDeletePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsDeletePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsDeletePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsDeletePostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsDeletePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsDisconnectSharedPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsDisconnectSharedPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsDisconnectSharedPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsDisconnectSharedPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsDisconnectSharedPostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsDisconnectSharedPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsEkmListOriginalConnectedChannelInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsEkmListOriginalConnectedChannelInfoGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsEkmListOriginalConnectedChannelInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsEkmListOriginalConnectedChannelInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsEkmListOriginalConnectedChannelInfoGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsEkmListOriginalConnectedChannelInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200Normalizer.php
@@ -102,7 +102,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetConversationPrefsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200PrefsCanThreadNormalizer.php
+++ b/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200PrefsCanThreadNormalizer.php
@@ -120,7 +120,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetConversationPrefsGetResponse200PrefsCanThread' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200PrefsNormalizer.php
+++ b/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200PrefsNormalizer.php
@@ -104,7 +104,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetConversationPrefsGetResponse200Prefs' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200PrefsWhoCanPostNormalizer.php
+++ b/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponse200PrefsWhoCanPostNormalizer.php
@@ -120,7 +120,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetConversationPrefsGetResponse200PrefsWhoCanPost' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsGetConversationPrefsGetResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetConversationPrefsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetTeamsGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsGetTeamsGetResponse200Normalizer.php
@@ -116,7 +116,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetTeamsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetTeamsGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/AdminConversationsGetTeamsGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetTeamsGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsGetTeamsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsGetTeamsGetResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsGetTeamsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsInvitePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsInvitePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsInvitePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsInvitePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsInvitePostResponsedefaultNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsInvitePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRenamePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsRenamePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRenamePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRenamePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsRenamePostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRenamePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRestrictAccessAddGroupPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsRestrictAccessAddGroupPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRestrictAccessAddGroupPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRestrictAccessAddGroupPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsRestrictAccessAddGroupPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRestrictAccessAddGroupPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRestrictAccessListGroupsGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsRestrictAccessListGroupsGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRestrictAccessListGroupsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRestrictAccessListGroupsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsRestrictAccessListGroupsGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRestrictAccessListGroupsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRestrictAccessRemoveGroupPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsRestrictAccessRemoveGroupPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRestrictAccessRemoveGroupPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsRestrictAccessRemoveGroupPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsRestrictAccessRemoveGroupPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsRestrictAccessRemoveGroupPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsSearchGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsSearchGetResponse200Normalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsSearchGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsSearchGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsSearchGetResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsSearchGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsSetConversationPrefsPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsSetConversationPrefsPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsSetConversationPrefsPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsSetConversationPrefsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsSetConversationPrefsPostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsSetConversationPrefsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsSetTeamsPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsSetTeamsPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsSetTeamsPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsSetTeamsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsSetTeamsPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsSetTeamsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsUnarchivePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminConversationsUnarchivePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsUnarchivePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminConversationsUnarchivePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminConversationsUnarchivePostResponsedefaultNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminConversationsUnarchivePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiAddAliasPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminEmojiAddAliasPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiAddAliasPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiAddAliasPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminEmojiAddAliasPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiAddAliasPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminEmojiAddPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminEmojiAddPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminEmojiListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminEmojiListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminEmojiRemovePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminEmojiRemovePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiRenamePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminEmojiRenamePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiRenamePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminEmojiRenamePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminEmojiRenamePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminEmojiRenamePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsApprovePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsApprovePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsApprovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsApprovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsApprovePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsApprovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsApprovedListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsApprovedListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsApprovedListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsApprovedListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsApprovedListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsApprovedListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsDeniedListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsDeniedListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsDeniedListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsDeniedListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsDeniedListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsDeniedListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsDenyPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsDenyPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsDenyPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsDenyPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsDenyPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsDenyPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminInviteRequestsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminInviteRequestsListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminInviteRequestsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsAdminsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsAdminsListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsAdminsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsAdminsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsAdminsListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsAdminsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsCreatePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsCreatePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsCreatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsCreatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsCreatePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsCreatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsOwnersListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsOwnersListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsOwnersListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsOwnersListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsOwnersListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsOwnersListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsInfoGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsInfoGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetDefaultChannelsPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetDefaultChannelsPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetDefaultChannelsPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetDefaultChannelsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetDefaultChannelsPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetDefaultChannelsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetDescriptionPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetDescriptionPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetDescriptionPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetDescriptionPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetDescriptionPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetDescriptionPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetDiscoverabilityPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetDiscoverabilityPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetDiscoverabilityPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetDiscoverabilityPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetDiscoverabilityPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetDiscoverabilityPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetIconPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetIconPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetIconPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetIconPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetIconPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetIconPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetNamePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetNamePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetNamePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminTeamsSettingsSetNamePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminTeamsSettingsSetNamePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminTeamsSettingsSetNamePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsAddChannelsPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsergroupsAddChannelsPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsAddChannelsPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsAddChannelsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsergroupsAddChannelsPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsAddChannelsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed: mixed
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsAddChannelsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsergroupsAddChannelsPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsAddChannelsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed: mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsAddTeamsPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsergroupsAddTeamsPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsAddTeamsPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsAddTeamsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsergroupsAddTeamsPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsAddTeamsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsListChannelsGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsergroupsListChannelsGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsListChannelsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsListChannelsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsergroupsListChannelsGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsListChannelsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsRemoveChannelsPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsergroupsRemoveChannelsPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsRemoveChannelsPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsergroupsRemoveChannelsPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsergroupsRemoveChannelsPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsergroupsRemoveChannelsPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersAssignPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersAssignPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersAssignPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersAssignPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersAssignPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersAssignPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersInvitePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersInvitePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersInvitePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersInvitePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersInvitePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersInvitePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersRemovePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersRemovePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSessionInvalidatePostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersSessionInvalidatePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSessionInvalidatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSessionInvalidatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersSessionInvalidatePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSessionInvalidatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSessionResetPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersSessionResetPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSessionResetPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSessionResetPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersSessionResetPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSessionResetPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetAdminPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersSetAdminPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetAdminPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetAdminPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersSetAdminPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetAdminPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetExpirationPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersSetExpirationPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetExpirationPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetExpirationPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersSetExpirationPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetExpirationPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetOwnerPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersSetOwnerPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetOwnerPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetOwnerPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersSetOwnerPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetOwnerPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetRegularPostResponse200Normalizer.php
+++ b/generated/Normalizer/AdminUsersSetRegularPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetRegularPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AdminUsersSetRegularPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AdminUsersSetRegularPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AdminUsersSetRegularPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ApiTestGetResponse200Normalizer.php
+++ b/generated/Normalizer/ApiTestGetResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ApiTestGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ApiTestGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ApiTestGetResponsedefaultNormalizer.php
@@ -121,7 +121,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ApiTestGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsEventAuthorizationsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsEventAuthorizationsListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsEventAuthorizationsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsEventAuthorizationsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsEventAuthorizationsListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsEventAuthorizationsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoAppHomeNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoAppHomeNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200InfoAppHome' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoChannelNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoChannelNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200InfoChannel' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoGroupNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoGroupNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200InfoGroup' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoImNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoImNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200InfoIm' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoMpimNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoMpimNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200InfoMpim' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200Info' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoTeamNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200InfoTeamNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200InfoTeam' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsRequestGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsPermissionsRequestGetResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsRequestGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsRequestGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsRequestGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsRequestGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsResourcesListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsPermissionsResourcesListGetResponse200Normalizer.php
@@ -129,7 +129,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsResourcesListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsResourcesListGetResponse200ResourcesItemNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsResourcesListGetResponse200ResourcesItemNormalizer.php
@@ -104,7 +104,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsResourcesListGetResponse200ResourcesItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsResourcesListGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsResourcesListGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsResourcesListGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsResourcesListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsResourcesListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsResourcesListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsScopesListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsPermissionsScopesListGetResponse200Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsScopesListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsScopesListGetResponse200ScopesNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsScopesListGetResponse200ScopesNormalizer.php
@@ -217,7 +217,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsScopesListGetResponse200Scopes' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsScopesListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsScopesListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsScopesListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsUsersListGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsPermissionsUsersListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsUsersListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsUsersListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsUsersListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsUsersListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsUsersRequestGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsPermissionsUsersRequestGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsUsersRequestGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsPermissionsUsersRequestGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsPermissionsUsersRequestGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsPermissionsUsersRequestGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsUninstallGetResponse200Normalizer.php
+++ b/generated/Normalizer/AppsUninstallGetResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsUninstallGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AppsUninstallGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AppsUninstallGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AppsUninstallGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AuthRevokeGetResponse200Normalizer.php
+++ b/generated/Normalizer/AuthRevokeGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AuthRevokeGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AuthRevokeGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AuthRevokeGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AuthRevokeGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AuthTestGetResponse200Normalizer.php
+++ b/generated/Normalizer/AuthTestGetResponse200Normalizer.php
@@ -140,7 +140,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AuthTestGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/AuthTestGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/AuthTestGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\AuthTestGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/BlocksItemNormalizer.php
+++ b/generated/Normalizer/BlocksItemNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\BlocksItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/BotsInfoGetResponse200BotIconsNormalizer.php
+++ b/generated/Normalizer/BotsInfoGetResponse200BotIconsNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\BotsInfoGetResponse200BotIcons' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/BotsInfoGetResponse200BotNormalizer.php
+++ b/generated/Normalizer/BotsInfoGetResponse200BotNormalizer.php
@@ -132,7 +132,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\BotsInfoGetResponse200Bot' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/BotsInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/BotsInfoGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\BotsInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/BotsInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/BotsInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\BotsInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/CallsAddPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/CallsAddPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsEndPostResponse200Normalizer.php
+++ b/generated/Normalizer/CallsEndPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsEndPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsEndPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/CallsEndPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsEndPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/CallsInfoGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/CallsInfoGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsParticipantsAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/CallsParticipantsAddPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsParticipantsAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsParticipantsAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/CallsParticipantsAddPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsParticipantsAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsParticipantsRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/CallsParticipantsRemovePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsParticipantsRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsParticipantsRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/CallsParticipantsRemovePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsParticipantsRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/CallsUpdatePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsUpdatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/CallsUpdatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/CallsUpdatePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\CallsUpdatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatDeletePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatDeletePostResponse200Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatDeletePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatDeletePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatDeletePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatDeletePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatDeleteScheduledMessagePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatDeleteScheduledMessagePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatDeleteScheduledMessagePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatDeleteScheduledMessagePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatDeleteScheduledMessagePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatDeleteScheduledMessagePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatGetPermalinkGetResponse200Normalizer.php
+++ b/generated/Normalizer/ChatGetPermalinkGetResponse200Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatGetPermalinkGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatGetPermalinkGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatGetPermalinkGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatGetPermalinkGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatMeMessagePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatMeMessagePostResponse200Normalizer.php
@@ -110,7 +110,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatMeMessagePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatMeMessagePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatMeMessagePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatMeMessagePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatPostEphemeralPostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatPostEphemeralPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatPostEphemeralPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatPostEphemeralPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatPostEphemeralPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatPostEphemeralPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatPostMessagePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatPostMessagePostResponse200Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatPostMessagePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatPostMessagePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatPostMessagePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatPostMessagePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduleMessagePostResponse200MessageAttachmentsItemNormalizer.php
+++ b/generated/Normalizer/ChatScheduleMessagePostResponse200MessageAttachmentsItemNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduleMessagePostResponse200MessageAttachmentsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduleMessagePostResponse200MessageNormalizer.php
+++ b/generated/Normalizer/ChatScheduleMessagePostResponse200MessageNormalizer.php
@@ -158,7 +158,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduleMessagePostResponse200Message' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduleMessagePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatScheduleMessagePostResponse200Normalizer.php
@@ -130,7 +130,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduleMessagePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduleMessagePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatScheduleMessagePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduleMessagePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduledMessagesListGetResponse200Normalizer.php
+++ b/generated/Normalizer/ChatScheduledMessagesListGetResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduledMessagesListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduledMessagesListGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ChatScheduledMessagesListGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduledMessagesListGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduledMessagesListGetResponse200ScheduledMessagesItemNormalizer.php
+++ b/generated/Normalizer/ChatScheduledMessagesListGetResponse200ScheduledMessagesItemNormalizer.php
@@ -132,7 +132,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduledMessagesListGetResponse200ScheduledMessagesItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatScheduledMessagesListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatScheduledMessagesListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatScheduledMessagesListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatUnfurlPostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatUnfurlPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatUnfurlPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatUnfurlPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatUnfurlPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatUnfurlPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatUpdatePostResponse200MessageNormalizer.php
+++ b/generated/Normalizer/ChatUpdatePostResponse200MessageNormalizer.php
@@ -118,7 +118,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatUpdatePostResponse200Message' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/ChatUpdatePostResponse200Normalizer.php
@@ -118,7 +118,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatUpdatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ChatUpdatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ChatUpdatePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ChatUpdatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsArchivePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsArchivePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsArchivePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsArchivePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsArchivePostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsArchivePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsClosePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsClosePostResponse200Normalizer.php
@@ -110,7 +110,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsClosePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsClosePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsClosePostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsClosePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsCreatePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsCreatePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsCreatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsCreatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsCreatePostResponsedefaultNormalizer.php
@@ -132,7 +132,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsCreatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsHistoryGetResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsHistoryGetResponse200Normalizer.php
@@ -140,7 +140,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsHistoryGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsHistoryGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ConversationsHistoryGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsHistoryGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsHistoryGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsHistoryGetResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsHistoryGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsInfoGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsInfoGetResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsInvitePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsInvitePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsInvitePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsInvitePostResponsedefaultErrorsItemNormalizer.php
+++ b/generated/Normalizer/ConversationsInvitePostResponsedefaultErrorsItemNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsInvitePostResponsedefaultErrorsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsInvitePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsInvitePostResponsedefaultNormalizer.php
@@ -142,7 +142,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsInvitePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsJoinPostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsJoinPostResponse200Normalizer.php
@@ -116,7 +116,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsJoinPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsJoinPostResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ConversationsJoinPostResponse200ResponseMetadataNormalizer.php
@@ -104,7 +104,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsJoinPostResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsJoinPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsJoinPostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsJoinPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsKickPostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsKickPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsKickPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsKickPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsKickPostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsKickPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsLeavePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsLeavePostResponse200Normalizer.php
@@ -102,7 +102,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsLeavePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsLeavePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsLeavePostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsLeavePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsListGetResponse200Normalizer.php
@@ -116,7 +116,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsListGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ConversationsListGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsListGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsListGetResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsMarkPostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsMarkPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsMarkPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsMarkPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsMarkPostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsMarkPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsMembersGetResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsMembersGetResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsMembersGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsMembersGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ConversationsMembersGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsMembersGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsMembersGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsMembersGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsMembersGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsOpenPostResponse200ChannelItem1Normalizer.php
+++ b/generated/Normalizer/ConversationsOpenPostResponse200ChannelItem1Normalizer.php
@@ -164,7 +164,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsOpenPostResponse200ChannelItem1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsOpenPostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsOpenPostResponse200Normalizer.php
@@ -116,7 +116,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsOpenPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsOpenPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsOpenPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsOpenPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRenamePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsRenamePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRenamePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRenamePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsRenamePostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRenamePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem0Normalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem0Normalizer.php
@@ -210,7 +210,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRepliesGetResponse200MessagesItemItem0' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem1Normalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200MessagesItemItem1Normalizer.php
@@ -164,7 +164,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRepliesGetResponse200MessagesItemItem1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRepliesGetResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200Normalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRepliesGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRepliesGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRepliesGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsRepliesGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsRepliesGetResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsRepliesGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsSetPurposePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsSetPurposePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsSetPurposePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsSetPurposePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsSetPurposePostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsSetPurposePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsSetTopicPostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsSetTopicPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsSetTopicPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsSetTopicPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsSetTopicPostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsSetTopicPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsUnarchivePostResponse200Normalizer.php
+++ b/generated/Normalizer/ConversationsUnarchivePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsUnarchivePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ConversationsUnarchivePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ConversationsUnarchivePostResponsedefaultNormalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ConversationsUnarchivePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DialogOpenGetResponse200Normalizer.php
+++ b/generated/Normalizer/DialogOpenGetResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DialogOpenGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DialogOpenGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DialogOpenGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DialogOpenGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndEndDndPostResponse200Normalizer.php
+++ b/generated/Normalizer/DndEndDndPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndEndDndPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndEndDndPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DndEndDndPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndEndDndPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndEndSnoozePostResponse200Normalizer.php
+++ b/generated/Normalizer/DndEndSnoozePostResponse200Normalizer.php
@@ -118,7 +118,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndEndSnoozePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndEndSnoozePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DndEndSnoozePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndEndSnoozePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/DndInfoGetResponse200Normalizer.php
@@ -136,7 +136,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DndInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndSetSnoozePostResponse200Normalizer.php
+++ b/generated/Normalizer/DndSetSnoozePostResponse200Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndSetSnoozePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndSetSnoozePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DndSetSnoozePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndSetSnoozePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndTeamInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/DndTeamInfoGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndTeamInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/DndTeamInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/DndTeamInfoGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\DndTeamInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/EmojiListGetResponse200Normalizer.php
+++ b/generated/Normalizer/EmojiListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\EmojiListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/EmojiListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/EmojiListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\EmojiListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesCommentsDeletePostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesCommentsDeletePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesCommentsDeletePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesCommentsDeletePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesCommentsDeletePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesCommentsDeletePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesDeletePostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesDeletePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesDeletePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesDeletePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesDeletePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesDeletePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/FilesInfoGetResponse200Normalizer.php
@@ -146,7 +146,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesListGetResponse200Normalizer.php
+++ b/generated/Normalizer/FilesListGetResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRemoteAddPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRemoteAddPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRemoteInfoGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRemoteInfoGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteListGetResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRemoteListGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRemoteListGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRemoteRemovePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRemoteRemovePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteShareGetResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRemoteShareGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteShareGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteShareGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRemoteShareGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteShareGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRemoteUpdatePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteUpdatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRemoteUpdatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRemoteUpdatePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRemoteUpdatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRevokePublicURLPostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesRevokePublicURLPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRevokePublicURLPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesRevokePublicURLPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesRevokePublicURLPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesRevokePublicURLPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesSharedPublicURLPostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesSharedPublicURLPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesSharedPublicURLPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesSharedPublicURLPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesSharedPublicURLPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesSharedPublicURLPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesUploadPostResponse200Normalizer.php
+++ b/generated/Normalizer/FilesUploadPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesUploadPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/FilesUploadPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/FilesUploadPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\FilesUploadPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/JaneObjectNormalizer.php
+++ b/generated/Normalizer/JaneObjectNormalizer.php
@@ -110,7 +110,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return $normalizer->normalize($object, $format, $context);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             $denormalizerClass = $this->normalizers[$type];
             $denormalizer = $this->getNormalizer($denormalizerClass);

--- a/generated/Normalizer/MigrationExchangeGetResponse200Normalizer.php
+++ b/generated/Normalizer/MigrationExchangeGetResponse200Normalizer.php
@@ -153,7 +153,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\MigrationExchangeGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/MigrationExchangeGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/MigrationExchangeGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\MigrationExchangeGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/OauthAccessGetResponse200Normalizer.php
+++ b/generated/Normalizer/OauthAccessGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\OauthAccessGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/OauthAccessGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/OauthAccessGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\OauthAccessGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/OauthTokenGetResponse200Normalizer.php
+++ b/generated/Normalizer/OauthTokenGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\OauthTokenGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/OauthTokenGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/OauthTokenGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\OauthTokenGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/OauthV2AccessGetResponse200Normalizer.php
+++ b/generated/Normalizer/OauthV2AccessGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\OauthV2AccessGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/OauthV2AccessGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/OauthV2AccessGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\OauthV2AccessGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsBotProfileIconsNormalizer.php
+++ b/generated/Normalizer/ObjsBotProfileIconsNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsBotProfileIcons' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsBotProfileNormalizer.php
+++ b/generated/Normalizer/ObjsBotProfileNormalizer.php
@@ -130,7 +130,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsBotProfile' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsChannelNormalizer.php
+++ b/generated/Normalizer/ObjsChannelNormalizer.php
@@ -345,7 +345,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsChannel' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsChannelPurposeNormalizer.php
+++ b/generated/Normalizer/ObjsChannelPurposeNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsChannelPurpose' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsChannelTopicNormalizer.php
+++ b/generated/Normalizer/ObjsChannelTopicNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsChannelTopic' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsCommentNormalizer.php
+++ b/generated/Normalizer/ObjsCommentNormalizer.php
@@ -192,7 +192,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsComment' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsConversationDisplayCountsNormalizer.php
+++ b/generated/Normalizer/ObjsConversationDisplayCountsNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsConversationDisplayCounts' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsConversationNormalizer.php
+++ b/generated/Normalizer/ObjsConversationNormalizer.php
@@ -603,7 +603,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsConversation' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsConversationPurposeNormalizer.php
+++ b/generated/Normalizer/ObjsConversationPurposeNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsConversationPurpose' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsConversationSharesItemNormalizer.php
+++ b/generated/Normalizer/ObjsConversationSharesItemNormalizer.php
@@ -134,7 +134,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsConversationSharesItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsConversationTopicNormalizer.php
+++ b/generated/Normalizer/ObjsConversationTopicNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsConversationTopic' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsEnterpriseUserNormalizer.php
+++ b/generated/Normalizer/ObjsEnterpriseUserNormalizer.php
@@ -132,7 +132,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsEnterpriseUser' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsExternalOrgMigrationsCurrentItemNormalizer.php
+++ b/generated/Normalizer/ObjsExternalOrgMigrationsCurrentItemNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsExternalOrgMigrationsCurrentItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsExternalOrgMigrationsNormalizer.php
+++ b/generated/Normalizer/ObjsExternalOrgMigrationsNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsExternalOrgMigrations' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsFileNormalizer.php
+++ b/generated/Normalizer/ObjsFileNormalizer.php
@@ -724,7 +724,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsFile' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsFileSharesNormalizer.php
+++ b/generated/Normalizer/ObjsFileSharesNormalizer.php
@@ -104,7 +104,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsFileShares' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsIconNormalizer.php
+++ b/generated/Normalizer/ObjsIconNormalizer.php
@@ -152,7 +152,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsIcon' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsMessageAttachmentsItemActionsItemNormalizer.php
+++ b/generated/Normalizer/ObjsMessageAttachmentsItemActionsItemNormalizer.php
@@ -136,7 +136,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsMessageAttachmentsItemActionsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsMessageAttachmentsItemFieldsItemNormalizer.php
+++ b/generated/Normalizer/ObjsMessageAttachmentsItemFieldsItemNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsMessageAttachmentsItemFieldsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsMessageAttachmentsItemNormalizer.php
+++ b/generated/Normalizer/ObjsMessageAttachmentsItemNormalizer.php
@@ -313,7 +313,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsMessageAttachmentsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsMessageIconsNormalizer.php
+++ b/generated/Normalizer/ObjsMessageIconsNormalizer.php
@@ -104,7 +104,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsMessageIcons' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsMessageNormalizer.php
+++ b/generated/Normalizer/ObjsMessageNormalizer.php
@@ -466,7 +466,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsMessage' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsMetadataNormalizer.php
+++ b/generated/Normalizer/ObjsMetadataNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsPagingNormalizer.php
+++ b/generated/Normalizer/ObjsPagingNormalizer.php
@@ -132,7 +132,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsPaging' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsPrimaryOwnerNormalizer.php
+++ b/generated/Normalizer/ObjsPrimaryOwnerNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsPrimaryOwner' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsReactionNormalizer.php
+++ b/generated/Normalizer/ObjsReactionNormalizer.php
@@ -127,7 +127,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsReaction' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsReminderNormalizer.php
+++ b/generated/Normalizer/ObjsReminderNormalizer.php
@@ -134,7 +134,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsReminder' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsResourcesNormalizer.php
+++ b/generated/Normalizer/ObjsResourcesNormalizer.php
@@ -126,7 +126,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsResources' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsResponseMetadataNormalizer.php
+++ b/generated/Normalizer/ObjsResponseMetadataNormalizer.php
@@ -126,7 +126,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsSubteamNormalizer.php
+++ b/generated/Normalizer/ObjsSubteamNormalizer.php
@@ -228,7 +228,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsSubteam' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsSubteamPrefsNormalizer.php
+++ b/generated/Normalizer/ObjsSubteamPrefsNormalizer.php
@@ -116,7 +116,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsSubteamPrefs' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsTeamNormalizer.php
+++ b/generated/Normalizer/ObjsTeamNormalizer.php
@@ -318,7 +318,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsTeam' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsTeamProfileFieldNormalizer.php
+++ b/generated/Normalizer/ObjsTeamProfileFieldNormalizer.php
@@ -177,7 +177,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsTeamProfileField' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsTeamProfileFieldOptionNormalizer.php
+++ b/generated/Normalizer/ObjsTeamProfileFieldOptionNormalizer.php
@@ -152,7 +152,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsTeamProfileFieldOption' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsTeamSsoProviderNormalizer.php
+++ b/generated/Normalizer/ObjsTeamSsoProviderNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsTeamSsoProvider' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsUserNormalizer.php
+++ b/generated/Normalizer/ObjsUserNormalizer.php
@@ -330,7 +330,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsUser' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsUserProfileNormalizer.php
+++ b/generated/Normalizer/ObjsUserProfileNormalizer.php
@@ -590,7 +590,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsUserProfile' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsUserProfileShortNormalizer.php
+++ b/generated/Normalizer/ObjsUserProfileShortNormalizer.php
@@ -166,7 +166,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsUserProfileShort' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ObjsUserTeamProfileNormalizer.php
+++ b/generated/Normalizer/ObjsUserTeamProfileNormalizer.php
@@ -102,7 +102,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ObjsUserTeamProfile' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/PinsAddPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/PinsAddPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsListGetResponse200Item0ItemsItem0Normalizer.php
+++ b/generated/Normalizer/PinsListGetResponse200Item0ItemsItem0Normalizer.php
@@ -120,7 +120,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsListGetResponse200Item0ItemsItem0' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsListGetResponse200Item0ItemsItem1Normalizer.php
+++ b/generated/Normalizer/PinsListGetResponse200Item0ItemsItem1Normalizer.php
@@ -128,7 +128,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsListGetResponse200Item0ItemsItem1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsListGetResponse200Item0Normalizer.php
+++ b/generated/Normalizer/PinsListGetResponse200Item0Normalizer.php
@@ -128,7 +128,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsListGetResponse200Item0' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsListGetResponse200Item1Normalizer.php
+++ b/generated/Normalizer/PinsListGetResponse200Item1Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsListGetResponse200Item1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/PinsListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/PinsRemovePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/PinsRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/PinsRemovePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\PinsRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/ReactionsAddPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ReactionsAddPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsGetGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ReactionsGetGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsGetGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsListGetResponse200ItemsItemItem0Normalizer.php
+++ b/generated/Normalizer/ReactionsListGetResponse200ItemsItemItem0Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsListGetResponse200ItemsItemItem0' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsListGetResponse200ItemsItemItem1Normalizer.php
+++ b/generated/Normalizer/ReactionsListGetResponse200ItemsItemItem1Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsListGetResponse200ItemsItemItem1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsListGetResponse200ItemsItemItem2Normalizer.php
+++ b/generated/Normalizer/ReactionsListGetResponse200ItemsItemItem2Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsListGetResponse200ItemsItemItem2' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/ReactionsListGetResponse200Normalizer.php
@@ -124,7 +124,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ReactionsListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/ReactionsRemovePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ReactionsRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ReactionsRemovePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ReactionsRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/RemindersAddPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/RemindersAddPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersCompletePostResponse200Normalizer.php
+++ b/generated/Normalizer/RemindersCompletePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersCompletePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersCompletePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/RemindersCompletePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersCompletePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersDeletePostResponse200Normalizer.php
+++ b/generated/Normalizer/RemindersDeletePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersDeletePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersDeletePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/RemindersDeletePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersDeletePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/RemindersInfoGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/RemindersInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersListGetResponse200Normalizer.php
+++ b/generated/Normalizer/RemindersListGetResponse200Normalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RemindersListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/RemindersListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RemindersListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RtmConnectGetResponse200Normalizer.php
+++ b/generated/Normalizer/RtmConnectGetResponse200Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RtmConnectGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RtmConnectGetResponse200SelfNormalizer.php
+++ b/generated/Normalizer/RtmConnectGetResponse200SelfNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RtmConnectGetResponse200Self' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RtmConnectGetResponse200TeamNormalizer.php
+++ b/generated/Normalizer/RtmConnectGetResponse200TeamNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RtmConnectGetResponse200Team' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/RtmConnectGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/RtmConnectGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\RtmConnectGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/SearchMessagesGetResponse200Normalizer.php
+++ b/generated/Normalizer/SearchMessagesGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\SearchMessagesGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/SearchMessagesGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/SearchMessagesGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\SearchMessagesGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsAddPostResponse200Normalizer.php
+++ b/generated/Normalizer/StarsAddPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsAddPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsAddPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/StarsAddPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsAddPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200ItemsItemItem0Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200ItemsItemItem0Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200ItemsItemItem0' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200ItemsItemItem1Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200ItemsItemItem1Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200ItemsItemItem1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200ItemsItemItem2Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200ItemsItemItem2Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200ItemsItemItem2' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200ItemsItemItem3Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200ItemsItemItem3Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200ItemsItemItem3' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200ItemsItemItem4Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200ItemsItemItem4Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200ItemsItemItem4' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200ItemsItemItem5Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200ItemsItemItem5Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200ItemsItemItem5' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/StarsListGetResponse200Normalizer.php
@@ -116,7 +116,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/StarsListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsRemovePostResponse200Normalizer.php
+++ b/generated/Normalizer/StarsRemovePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsRemovePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/StarsRemovePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/StarsRemovePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\StarsRemovePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamAccessLogsGetResponse200LoginsItemNormalizer.php
+++ b/generated/Normalizer/TeamAccessLogsGetResponse200LoginsItemNormalizer.php
@@ -180,7 +180,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamAccessLogsGetResponse200LoginsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamAccessLogsGetResponse200Normalizer.php
+++ b/generated/Normalizer/TeamAccessLogsGetResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamAccessLogsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamAccessLogsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/TeamAccessLogsGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamAccessLogsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamBillableInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/TeamBillableInfoGetResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamBillableInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamBillableInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/TeamBillableInfoGetResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamBillableInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/TeamInfoGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/TeamInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamIntegrationLogsGetResponse200LogsItemNormalizer.php
+++ b/generated/Normalizer/TeamIntegrationLogsGetResponse200LogsItemNormalizer.php
@@ -162,7 +162,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamIntegrationLogsGetResponse200LogsItem' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamIntegrationLogsGetResponse200Normalizer.php
+++ b/generated/Normalizer/TeamIntegrationLogsGetResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamIntegrationLogsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamIntegrationLogsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/TeamIntegrationLogsGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamIntegrationLogsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamProfileGetGetResponse200Normalizer.php
+++ b/generated/Normalizer/TeamProfileGetGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamProfileGetGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamProfileGetGetResponse200ProfileNormalizer.php
+++ b/generated/Normalizer/TeamProfileGetGetResponse200ProfileNormalizer.php
@@ -102,7 +102,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamProfileGetGetResponse200Profile' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/TeamProfileGetGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/TeamProfileGetGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\TeamProfileGetGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsCreatePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsCreatePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsCreatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsCreatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsCreatePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsCreatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsDisablePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsDisablePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsDisablePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsDisablePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsDisablePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsDisablePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsEnablePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsEnablePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsEnablePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsEnablePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsEnablePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsEnablePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsListGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsListGetResponse200Normalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsUpdatePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsUpdatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsUpdatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsUpdatePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsUpdatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsUsersListGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsUsersListGetResponse200Normalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsUsersListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsUsersListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsUsersListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsUsersListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsUsersUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsergroupsUsersUpdatePostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsUsersUpdatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsergroupsUsersUpdatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsergroupsUsersUpdatePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsergroupsUsersUpdatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersConversationsGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsersConversationsGetResponse200Normalizer.php
@@ -129,7 +129,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersConversationsGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersConversationsGetResponse200ResponseMetadataNormalizer.php
+++ b/generated/Normalizer/UsersConversationsGetResponse200ResponseMetadataNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersConversationsGetResponse200ResponseMetadata' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersConversationsGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersConversationsGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersConversationsGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersDeletePhotoPostResponse200Normalizer.php
+++ b/generated/Normalizer/UsersDeletePhotoPostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersDeletePhotoPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersDeletePhotoPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersDeletePhotoPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersDeletePhotoPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersGetPresenceGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsersGetPresenceGetResponse200Normalizer.php
@@ -157,7 +157,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersGetPresenceGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersGetPresenceGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersGetPresenceGetResponsedefaultNormalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersGetPresenceGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item0Normalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item0Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item0' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item0TeamNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item0TeamNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item0Team' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item0UserNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item0UserNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item0User' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item1Normalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item1Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item1' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item1TeamNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item1TeamNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item1Team' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item1UserNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item1UserNormalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item1User' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item2Normalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item2Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item2' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item2TeamNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item2TeamNormalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item2Team' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item2UserNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item2UserNormalizer.php
@@ -136,7 +136,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item2User' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item3Normalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item3Normalizer.php
@@ -106,7 +106,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item3' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item3TeamNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item3TeamNormalizer.php
@@ -154,7 +154,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item3Team' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponse200Item3UserNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponse200Item3UserNormalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponse200Item3User' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersIdentityGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersIdentityGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersIdentityGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersInfoGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsersInfoGetResponse200Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersInfoGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersInfoGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersInfoGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersInfoGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersListGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsersListGetResponse200Normalizer.php
@@ -122,7 +122,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersListGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersListGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersListGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersListGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersLookupByEmailGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsersLookupByEmailGetResponse200Normalizer.php
@@ -112,7 +112,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersLookupByEmailGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersLookupByEmailGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersLookupByEmailGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersLookupByEmailGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersProfileGetGetResponse200Normalizer.php
+++ b/generated/Normalizer/UsersProfileGetGetResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersProfileGetGetResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersProfileGetGetResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersProfileGetGetResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersProfileGetGetResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersProfileSetPostResponse200Normalizer.php
+++ b/generated/Normalizer/UsersProfileSetPostResponse200Normalizer.php
@@ -114,7 +114,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersProfileSetPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersProfileSetPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersProfileSetPostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersProfileSetPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetActivePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsersSetActivePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetActivePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetActivePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersSetActivePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetActivePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetPhotoPostResponse200Normalizer.php
+++ b/generated/Normalizer/UsersSetPhotoPostResponse200Normalizer.php
@@ -100,7 +100,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetPhotoPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetPhotoPostResponse200ProfileNormalizer.php
+++ b/generated/Normalizer/UsersSetPhotoPostResponse200ProfileNormalizer.php
@@ -142,7 +142,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetPhotoPostResponse200Profile' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetPhotoPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersSetPhotoPostResponsedefaultNormalizer.php
@@ -132,7 +132,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetPhotoPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetPresencePostResponse200Normalizer.php
+++ b/generated/Normalizer/UsersSetPresencePostResponse200Normalizer.php
@@ -94,7 +94,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetPresencePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/UsersSetPresencePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/UsersSetPresencePostResponsedefaultNormalizer.php
@@ -108,7 +108,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\UsersSetPresencePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsOpenPostResponse200Normalizer.php
+++ b/generated/Normalizer/ViewsOpenPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsOpenPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsOpenPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ViewsOpenPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsOpenPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsPublishPostResponse200Normalizer.php
+++ b/generated/Normalizer/ViewsPublishPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsPublishPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsPublishPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ViewsPublishPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsPublishPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsPushPostResponse200Normalizer.php
+++ b/generated/Normalizer/ViewsPushPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsPushPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsPushPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ViewsPushPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsPushPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsUpdatePostResponse200Normalizer.php
+++ b/generated/Normalizer/ViewsUpdatePostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsUpdatePostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/ViewsUpdatePostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/ViewsUpdatePostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\ViewsUpdatePostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/WorkflowsStepCompletedPostResponse200Normalizer.php
+++ b/generated/Normalizer/WorkflowsStepCompletedPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\WorkflowsStepCompletedPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/WorkflowsStepCompletedPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/WorkflowsStepCompletedPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\WorkflowsStepCompletedPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/WorkflowsStepFailedPostResponse200Normalizer.php
+++ b/generated/Normalizer/WorkflowsStepFailedPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\WorkflowsStepFailedPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/WorkflowsStepFailedPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/WorkflowsStepFailedPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\WorkflowsStepFailedPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/WorkflowsUpdateStepPostResponse200Normalizer.php
+++ b/generated/Normalizer/WorkflowsUpdateStepPostResponse200Normalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\WorkflowsUpdateStepPostResponse200' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);

--- a/generated/Normalizer/WorkflowsUpdateStepPostResponsedefaultNormalizer.php
+++ b/generated/Normalizer/WorkflowsUpdateStepPostResponsedefaultNormalizer.php
@@ -105,7 +105,7 @@ if (!class_exists(Kernel::class) || (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR
             return \is_object($data) && 'JoliCode\\Slack\\Api\\Model\\WorkflowsUpdateStepPostResponsedefault' === \get_class($data);
         }
 
-        public function denormalize($data, $type, $format = null, array $context = [])
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
         {
             if (isset($data['$ref'])) {
                 return new Reference($data['$ref'], $context['document-origin']);


### PR DESCRIPTION
Should resolves this:
`User Deprecated: Method "Symfony\Component\Serializer\Normalizer\DenormalizerInterface::denormalize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "JoliCode\Slack\Api\Normalizer\JaneObjectNormalizer" now to avoid errors or add an explicit @return annotation to suppress this message.`