### PR TITLE
Enable file uploads inside threads 

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,10 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!--<server name="SLACK_TOKEN" value="edit_me" />-->
-        <!--<server name="SLACK_TEST_CHANNEL" value="edit_me" /> // should be the channel ID, not name-->
-        <!--<server name="SLACK_TEST_THREAD_TS" value="edit_me" /> // set this to test uploads in a thread -->
+        <!-- should be the channel ID, not name -->
+        <!--<server name="SLACK_TEST_CHANNEL" value="edit_me" />-->
+        <!-- set this to test uploads in a thread -->
+        <!--<server name="SLACK_TEST_THREAD_TS" value="edit_me" />-->
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,8 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!--<server name="SLACK_TOKEN" value="edit_me" />-->
-        <!--<server name="SLACK_TEST_CHANNEL" value="edit_me" />-->
+        <!--<server name="SLACK_TEST_CHANNEL" value="edit_me" /> // should be the channel ID, not name-->
+        <!--<server name="SLACK_TEST_THREAD_TS" value="edit_me" /> // set this to test uploads in a thread -->
     </php>
 
     <testsuites>

--- a/src/Client.php
+++ b/src/Client.php
@@ -99,6 +99,7 @@ class Client extends ApiClient
      *                                    ]
      * @param string      $channelId      The Slack channel ID to upload files to (e.g., 'C12345678').
      * @param string|null $initialComment optional comment to add with the upload
+     * @param string|null $threadTs optional threadts to use with the upload
      *
      * @throws \RuntimeException        if upload or Slack API interaction fails
      * @throws \JsonException
@@ -114,6 +115,7 @@ class Client extends ApiClient
         array $files,
         string $channelId,
         ?string $initialComment = null,
+        ?string $threadTs = null,
     ): FilesCompleteUploadExternalPostResponsedefault|FilesCompleteUploadExternalPostResponse200|null {
         $filesPayload = [];
 
@@ -161,6 +163,7 @@ class Client extends ApiClient
                 [
                     'files' => json_encode($filesPayload, \JSON_THROW_ON_ERROR),
                     'channel_id' => $channelId,
+                    'thread_ts' => $threadTs,
                     'initial_comment' => $initialComment,
                 ]
             )

--- a/src/Client.php
+++ b/src/Client.php
@@ -99,7 +99,7 @@ class Client extends ApiClient
      *                                    ]
      * @param string      $channelId      The Slack channel ID to upload files to (e.g., 'C12345678').
      * @param string|null $initialComment optional comment to add with the upload
-     * @param string|null $threadTs optional threadts to use with the upload
+     * @param string|null $threadTs       optional threadts to use with the upload
      *
      * @throws \RuntimeException        if upload or Slack API interaction fails
      * @throws \JsonException

--- a/src/Client.php
+++ b/src/Client.php
@@ -99,7 +99,7 @@ class Client extends ApiClient
      *                                    ]
      * @param string      $channelId      The Slack channel ID to upload files to (e.g., 'C12345678').
      * @param string|null $initialComment optional comment to add with the upload
-     * @param string|null $threadTs       optional threadts to use with the upload
+     * @param string|null $threadTs       optional thread_ts (Slack thread timestamp) to attach the upload to a thread
      *
      * @throws \RuntimeException        if upload or Slack API interaction fails
      * @throws \JsonException

--- a/tests/WritingTest.php
+++ b/tests/WritingTest.php
@@ -174,7 +174,7 @@ class WritingTest extends SlackTokenDependentTest
         $filePath = __DIR__ . '/resources/' . $fileName;
         $fileStream = Stream::create(fopen($filePath, 'r'));
         $fileSize = $fileStream->getSize();
-        $threadTs = 'ts.some-thread-ts';
+        $threadTs = $_SERVER['SLACK_TEST_THREAD_TS'];
 
         $response = $client->filesGetUploadUrlExternal(
             [

--- a/tests/WritingTest.php
+++ b/tests/WritingTest.php
@@ -174,7 +174,7 @@ class WritingTest extends SlackTokenDependentTest
         $filePath = __DIR__ . '/resources/' . $fileName;
         $fileStream = Stream::create(fopen($filePath, 'r'));
         $fileSize = $fileStream->getSize();
-        $threadTs = $_SERVER['SLACK_TEST_THREAD_TS'];
+        $threadTs = $_SERVER['SLACK_TEST_THREAD_TS'] ?? null;
 
         $response = $client->filesGetUploadUrlExternal(
             [

--- a/tests/WritingTest.php
+++ b/tests/WritingTest.php
@@ -174,6 +174,7 @@ class WritingTest extends SlackTokenDependentTest
         $filePath = __DIR__ . '/resources/' . $fileName;
         $fileStream = Stream::create(fopen($filePath, 'r'));
         $fileSize = $fileStream->getSize();
+        $threadTs = 'ts.some-thread-ts';
 
         $response = $client->filesGetUploadUrlExternal(
             [
@@ -191,7 +192,7 @@ class WritingTest extends SlackTokenDependentTest
 
         $uploadResponse = $client->filesUploadV2([
             ['path' => $filePath, 'title' => 'Test image', 'alt_text' => 'Test image'],
-        ], $_SERVER['SLACK_TEST_CHANNEL'], 'Uploaded with the 2025 API.');
+        ], $_SERVER['SLACK_TEST_CHANNEL'], 'Uploaded with the 2025 API.', $threadTs);
 
         self::assertTrue($uploadResponse->getOk());
     }


### PR DESCRIPTION
This PR will allow file uploads inside threads, useful when you have a bot in a thread returning a file. 
see slack documentation: https://docs.slack.dev/reference/methods/files.completeUploadExternal/#:~:text=Example%3A%20C0NF841BK-,thread_ts,-string

Tested on a dev slack app

<img width="879" height="574" alt="image" src="https://github.com/user-attachments/assets/ac336b2c-b328-4a37-9930-4e581e5b40ff" />
